### PR TITLE
Phase 2: modular provider architecture + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  smoke-test:
+    name: Smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: sudo apt-get install -y shellcheck
+
+      - name: Run smoke tests
+        run: bash scripts/smoke-test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   smoke-test:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,12 +1,18 @@
-on: push
+# Superseded by ci.yml — shellcheck is now run as part of scripts/smoke-test.sh.
+# Kept as a manual trigger only to avoid breaking any external references.
+on:
+  workflow_dispatch:
 
-name: 'ShellCheck'
+name: ShellCheck (legacy)
 
 jobs:
   shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Run ShellCheck
-      uses: ludeeus/action-shellcheck@master
+      - uses: actions/checkout@v4
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          severity: warning
+          additional_files: providers/*.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 *.tags
 *.tags1
+
+# Provider config files — must never be committed; download at runtime to /tmp/
+*.ovpn
+*.zip
+*.p12
+*.pem

--- a/README.md
+++ b/README.md
@@ -59,6 +59,38 @@ If that doesn't work:
 
 ![CLI UI](https://puu.sh/HevPC/4f5ddfc3d6.png)
 
+## Roadmap
+
+Work progresses in phases. Completed phases are merged to `main`; in-progress work is on feature branches.
+
+- [x] **Phase 1** — Fork merge: jackyaz's v2.3.2 merged back as the new baseline, WeVPN ZIP files removed
+- [x] **Phase 2** — Modular provider architecture: all provider logic extracted to `providers/provider_<name>.sh`; CI smoke test added
+- [ ] **Phase 3** — URL and branding sweep: remaining `jackyaz` references in WebUI files, banner/header update, integrity check
+- [ ] **Phase 4** — WebUI adaptation: ES6 → ES5, dynamic country/city dropdowns from provider data files (not hardcoded JS arrays), provider selection per VPN client
+- [ ] **Phase 5** — Full documentation: provider module authoring guide, contributing guide, updated CLI/WebUI screenshots
+- [ ] **Tooling** — Claude Code agents/skills for scaffolding a new provider module and running provider smoke tests on a live router
+
+## Development
+
+### Installing from a branch
+
+Replace `<branch>` with the branch name (e.g. `feat/phase4-webui`):
+
+```sh
+/usr/sbin/curl --retry 3 "https://raw.githubusercontent.com/h0me5k1n/asusmerlin-nvpnmgr/<branch>/vpnmgr.sh" -o "/jffs/scripts/vpnmgr" && chmod 0755 /jffs/scripts/vpnmgr && /jffs/scripts/vpnmgr install
+```
+
+To switch a running installation between the stable release and the `develop` branch:
+
+```sh
+vpnmgr switch stable    # pins to main
+vpnmgr switch develop   # pins to develop branch
+```
+
+### Adding a provider
+
+Copy `providers/provider_template.sh` to `providers/provider_<name>.sh` and implement all 17 required functions. The contract is documented in the template header. Run `bash scripts/smoke-test.sh` locally to verify contract completeness before opening a PR — CI enforces this on every push.
+
 ## Credits
 
 - [@jackyaz](https://github.com/jackyaz) — author of the expanded vpnmgr (WebUI, multi-provider, self-update, scheduling). His 429 commits are the backbone of this codebase.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vpnmgr
 
-![Shellcheck](https://github.com/h0me5k1n/asusmerlin-nvpnmgr/actions/workflows/shellcheck.yml/badge.svg)
+![CI](https://github.com/h0me5k1n/asusmerlin-nvpnmgr/actions/workflows/ci.yml/badge.svg)
 
 VPN client manager for AsusWRT-Merlin routers.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Merlin 384.15/384.13_4 or Fork 43E5 (or later) — [Asuswrt-Merlin](https://asus
 Using your preferred SSH client/terminal:
 
 ```sh
-/usr/sbin/curl --retry 3 "https://raw.githubusercontent.com/h0me5k1n/asusmerlin-nvpnmgr/master/vpnmgr.sh" -o "/jffs/scripts/vpnmgr" && chmod 0755 /jffs/scripts/vpnmgr && /jffs/scripts/vpnmgr install
+/usr/sbin/curl --retry 3 "https://raw.githubusercontent.com/h0me5k1n/asusmerlin-nvpnmgr/main/vpnmgr.sh" -o "/jffs/scripts/vpnmgr" && chmod 0755 /jffs/scripts/vpnmgr && /jffs/scripts/vpnmgr install
 ```
 
 > **Note:** This repo is being renamed from `asusmerlin-nvpnmgr` to `vpnmgr` on GitHub. The installation URL will update accordingly — GitHub will redirect the old URL automatically.

--- a/providers/provider_nordvpn.sh
+++ b/providers/provider_nordvpn.sh
@@ -1,0 +1,240 @@
+#!/bin/sh
+# NordVPN provider module for vpnmgr
+# Status: ACTIVE
+#
+# Depends on: jq, curl
+# Cache file: $SCRIPT_DIR/nordvpn_countrydata  (JSON array from NordVPN API)
+
+##########         Shellcheck directives     ##########
+# shellcheck disable=SC2039
+# shellcheck disable=SC3043
+#######################################################
+
+provider_nordvpn_version(){
+	printf "v1.0.0\n"
+}
+
+# Map human-readable type names to NordVPN API group identifiers
+_nordvpn_type_to_api(){
+	case "$1" in
+		Standard)   printf "legacy_standard" ;;
+		Double)     printf "legacy_double_vpn" ;;
+		P2P)        printf "legacy_p2p" ;;
+		Obfuscated) printf "legacy_obfuscated" ;;
+		*)          printf "legacy_standard" ;;
+	esac
+}
+
+# Map protocol SHORT (UDP/TCP) to NordVPN technology identifier
+_nordvpn_prot_to_api(){
+	case "$1" in
+		UDP) printf "openvpn_udp" ;;
+		TCP) printf "openvpn_tcp" ;;
+		*)   printf "openvpn_udp" ;;
+	esac
+}
+
+# provider_nordvpn_get_server country_id country_name city_id city_name protocol vpn_type
+# Prints the server hostname on stdout.
+provider_nordvpn_get_server(){
+	_nord_countryid="$1"
+	_nord_cityid="$3"
+	_nord_prot="$5"
+	_nord_type="$6"
+
+	_nord_api_type="$(_nordvpn_type_to_api "$_nord_type")"
+	_nord_api_prot="$(_nordvpn_prot_to_api "$_nord_prot")"
+
+	_nord_vjson=""
+
+	if [ "$_nord_countryid" -eq 0 ] 2>/dev/null || [ -z "$_nord_countryid" ]; then
+		# No country filter — worldwide
+		_nord_vjson="$(_nordvpn_get_recommended "$_nord_api_type" "$_nord_api_prot" 0)"
+	elif [ "$_nord_cityid" -eq 0 ] 2>/dev/null || [ -z "$_nord_cityid" ]; then
+		# Country only
+		_nord_vjson="$(_nordvpn_get_recommended "$_nord_api_type" "$_nord_api_prot" "$_nord_countryid")"
+	else
+		# City + country
+		_nord_vjson="$(_nordvpn_get_city "$_nord_api_type" "$_nord_api_prot" "$_nord_countryid" "$_nord_cityid")"
+		if [ -z "$_nord_vjson" ]; then
+			Print_Output true "NordVPN: No server found for city, falling back to country" "$WARN"
+			_nord_vjson="$(_nordvpn_get_recommended "$_nord_api_type" "$_nord_api_prot" "$_nord_countryid")"
+		fi
+		if [ -z "$_nord_vjson" ]; then
+			Print_Output true "NordVPN: No server found for country, falling back to worldwide" "$WARN"
+			_nord_vjson="$(_nordvpn_get_recommended "$_nord_api_type" "$_nord_api_prot" 0)"
+		fi
+	fi
+
+	[ -z "$_nord_vjson" ] && Print_Output true "NordVPN: API returned no servers" "$ERR" && return 1
+
+	_nord_hostname="$(printf '%s' "$_nord_vjson" | jq -r -e '.hostname // empty')"
+	[ -z "$_nord_hostname" ] && Print_Output true "NordVPN: Could not determine hostname" "$ERR" && return 1
+
+	printf '%s' "$_nord_hostname"
+}
+
+_nordvpn_get_recommended(){
+	_nr_type="$1"
+	_nr_prot="$2"
+	_nr_cid="$3"
+	_nr_url="https://api.nordvpn.com/v1/servers/recommendations?filters[servers_groups][identifier]=${_nr_type}&filters[servers_technologies][identifier]=${_nr_prot}"
+	if [ "$_nr_cid" -ne 0 ] 2>/dev/null; then
+		_nr_url="${_nr_url}&filters[country_id]=${_nr_cid}"
+	fi
+	_nr_url="${_nr_url}&limit=1"
+	/usr/sbin/curl -fsL --retry 3 "$_nr_url" | jq -r -e '.[] // empty'
+}
+
+_nordvpn_get_city(){
+	_nc_type="$1"
+	_nc_prot="$2"
+	_nc_cid="$3"
+	_nc_cityid="$4"
+	/usr/sbin/curl -fsL --retry 3 \
+		"https://api.nordvpn.com/v1/servers/recommendations?filters[servers_groups][identifier]=${_nc_type}&filters[servers_technologies][identifier]=${_nc_prot}&filters[country_id]=${_nc_cid}&limit=2500" \
+		| jq -r -e "[ .[] | select(.locations[].country.city.id==${_nc_cityid})][0] // empty"
+}
+
+# provider_nordvpn_get_ovpn hostname protocol vpn_type
+# Downloads OVPN file from NordVPN CDN and prints contents to stdout.
+provider_nordvpn_get_ovpn(){
+	_gov_hostname="$1"
+	_gov_prot="$2"
+	_gov_prot_lc="$(printf '%s' "$_gov_prot" | tr 'A-Z' 'a-z')"
+	/usr/sbin/curl -fsL --retry 3 \
+		"https://downloads.nordcdn.com/configs/files/ovpn_${_gov_prot_lc}/servers/${_gov_hostname}.${_gov_prot_lc}.ovpn"
+}
+
+# provider_nordvpn_get_comp
+provider_nordvpn_get_comp(){
+	printf -- "-1"
+}
+
+# provider_nordvpn_get_hmac
+provider_nordvpn_get_hmac(){
+	printf "1"
+}
+
+# provider_nordvpn_get_short_name hostname addr
+provider_nordvpn_get_short_name(){
+	printf '%s' "$1" | cut -f1 -d'.' | tr 'a-z' 'A-Z'
+}
+
+# provider_nordvpn_write_certs vpn_no ovpn_detail
+# Writes ca + static (tls-auth); removes crl, key, crt.
+provider_nordvpn_write_certs(){
+	_wc_no="$1"
+	_wc_ovpn="$2"
+
+	_wc_ca="$(printf '%s' "$_wc_ovpn" | awk '/<ca>/{flag=1;next}/<\/ca>/{flag=0}flag' | sed '/^#/ d')"
+	[ -z "$_wc_ca" ] && Print_Output true "NordVPN: Error determining CA certificate" "$ERR" && return 1
+
+	_wc_static="$(printf '%s' "$_wc_ovpn" | awk '/<tls-auth>/{flag=1;next}/<\/tls-auth>/{flag=0}flag' | sed '/^#/ d')"
+	[ -z "$_wc_static" ] && Print_Output true "NordVPN: Error determining static (tls-auth) key" "$ERR" && return 1
+
+	printf '%s\n' "$_wc_ca"     > /jffs/openvpn/vpn_crt_client"${_wc_no}"_ca
+	printf '%s\n' "$_wc_static" > /jffs/openvpn/vpn_crt_client"${_wc_no}"_static
+	rm -f /jffs/openvpn/vpn_crt_client"${_wc_no}"_crl
+	rm -f /jffs/openvpn/vpn_crt_client"${_wc_no}"_key
+	rm -f /jffs/openvpn/vpn_crt_client"${_wc_no}"_crt
+}
+
+# provider_nordvpn_get_country_names
+# Reads cached country data JSON and prints country names, one per line.
+provider_nordvpn_get_country_names(){
+	_cdata="$SCRIPT_DIR/nordvpn_countrydata"
+	if [ ! -f "$_cdata" ]; then
+		Print_Output true "NordVPN: Country data cache missing — run refreshcacheddata" "$ERR"
+		return 1
+	fi
+	jq -r -e '.[] | .name // empty' "$_cdata"
+}
+
+# provider_nordvpn_get_country_id country_name
+provider_nordvpn_get_country_id(){
+	_cdata="$SCRIPT_DIR/nordvpn_countrydata"
+	jq -r -e ".[] | select(.name==\"$1\") | .id // empty" "$_cdata"
+}
+
+# provider_nordvpn_get_city_count country_name
+provider_nordvpn_get_city_count(){
+	_cdata="$SCRIPT_DIR/nordvpn_countrydata"
+	jq -r -e ".[] | select(.name==\"$1\") | .cities | length // empty" "$_cdata"
+}
+
+# provider_nordvpn_get_city_names country_name
+provider_nordvpn_get_city_names(){
+	_cdata="$SCRIPT_DIR/nordvpn_countrydata"
+	jq -r -e ".[] | select(.name==\"$1\") | .cities[] | .name // empty" "$_cdata"
+}
+
+# provider_nordvpn_get_city_id country_name city_name
+provider_nordvpn_get_city_id(){
+	_cdata="$SCRIPT_DIR/nordvpn_countrydata"
+	jq -r -e ".[] | select(.name==\"$1\") | .cities[] | select(.name==\"$2\") | .id // empty" "$_cdata"
+}
+
+# provider_nordvpn_country_required
+# Returns 1 — country selection is optional for NordVPN.
+provider_nordvpn_country_required(){
+	return 1
+}
+
+# provider_nordvpn_city_required
+# Returns 1 — city selection is optional for NordVPN.
+provider_nordvpn_city_required(){
+	return 1
+}
+
+# provider_nordvpn_get_types
+# Prints available VPN types, one per line.
+provider_nordvpn_get_types(){
+	printf "Standard\nDouble\nP2P\n"
+}
+
+# provider_nordvpn_get_server_load desc
+# desc: nvram vpn_clientX_desc value containing hostname
+provider_nordvpn_get_server_load(){
+	_sl_desc="$1"
+	_sl_host="$(printf '%s' "$_sl_desc" | cut -f2 -d ' ' | tr 'A-Z' 'a-z').nordvpn.com"
+	/usr/sbin/curl -fsL --retry 3 "https://api.nordvpn.com/server/stats/${_sl_host}" \
+		| jq -r -e '.percent // "Unknown"'
+}
+
+# provider_nordvpn_refresh_cache
+# Downloads NordVPN country data, compares with cached copy, updates if changed.
+provider_nordvpn_refresh_cache(){
+	Print_Output true "NordVPN: Refreshing country data..."
+	/usr/sbin/curl -fsL --retry 3 "https://api.nordvpn.com/v1/servers/countries" \
+		| jq -r > /tmp/nordvpn_countrydata
+	_rc_data="$(cat /tmp/nordvpn_countrydata)"
+	if [ -z "$_rc_data" ]; then
+		Print_Output true "NordVPN: Country data failed to download" "$ERR"
+		rm -f /tmp/nordvpn_countrydata
+		return 1
+	fi
+	if [ -f "$SCRIPT_DIR/nordvpn_countrydata" ]; then
+		if ! diff -q /tmp/nordvpn_countrydata "$SCRIPT_DIR/nordvpn_countrydata" >/dev/null 2>&1; then
+			mv /tmp/nordvpn_countrydata "$SCRIPT_DIR/nordvpn_countrydata"
+			Print_Output true "NordVPN: Country data updated" "$PASS"
+			Create_Symlinks
+		else
+			rm -f /tmp/nordvpn_countrydata
+			Print_Output true "NordVPN: Country data unchanged" "$WARN"
+		fi
+	else
+		mv /tmp/nordvpn_countrydata "$SCRIPT_DIR/nordvpn_countrydata"
+		Create_Symlinks
+		Print_Output true "NordVPN: Country data downloaded (first run)" "$PASS"
+	fi
+}
+
+# provider_nordvpn_needs_cache
+# Returns 0 (needs refresh) if cache file is missing, 1 if present.
+provider_nordvpn_needs_cache(){
+	if [ ! -f "$SCRIPT_DIR/nordvpn_countrydata" ]; then
+		return 0
+	fi
+	return 1
+}

--- a/providers/provider_pia.sh
+++ b/providers/provider_pia.sh
@@ -1,0 +1,223 @@
+#!/bin/sh
+# PIA (Private Internet Access) provider module for vpnmgr
+# Status: UNMAINTAINED — extracted from jackyaz's vpnmgr v2.3.2
+#
+# Depends on: 7za (p7zip), curl
+# Cache files: $OVPN_ARCHIVE_DIR/pia_*.zip, $SCRIPT_DIR/pia_countrydata
+
+##########         Shellcheck directives     ##########
+# shellcheck disable=SC2039
+# shellcheck disable=SC3043
+#######################################################
+
+provider_pia_version(){
+	printf "v1.0.0\n"
+}
+
+# Internal: translate country name to PIA country code prefix
+_pia_sed_country_codes_destructive(){
+	sed 's/ /_/g;s/^AU_.*/Australia/I;s/^CA_.*/Canada/I;s/^DE_.*/Germany/I;s/^UAE_.*/United Arab Emirates/I;s/^UK_.*/United Kingdom/I;s/^US_.*/United States/I;
+s/^AE_.*/United Arab Emirates/I;s/^GB_.*/United Kingdom/I;s/^AT_.*/Austria/I;s/^BE_.*/Belgium/I;s/^BG_.*/Bulgaria/I;s/^BR_.*/Brazil/I;
+s/^CH_.*/Switzerland/I;s/^CZ_.*/Czech Republic/I;s/^DK_.*/Denmark/I;s/^ES_.*/Spain/I;s/^FR_.*/France/I;s/^HK_.*/Hong Kong/I;s/^HU_.*/Hungary/I;
+s/^IE_.*/Ireland/I;s/^IL_.*/Israel/I;s/^IN_.*/India/I;s/^IT_.*/Italy/I;s/^JP_.*/Japan/I;s/^MX_.*/Mexico/I;s/^NL_.*/Netherlands/I;s/^NO_.*/Norway/I;s/^NZ_.*/New Zealand/I;
+s/^PL_.*/Poland/I;s/^RO_.*/Romania/I;s/^RS_.*/Serbia/I;s/^SE_.*/Sweden/I;s/^SG_.*/Singapore/I;s/^ZA_.*/South Africa/I;s/_/ /g;'
+}
+
+_pia_sed_country_codes(){
+	sed 's/ /_/g;s/^AU_/Australia/I;s/^CA_/Canada/I;s/^DE_/Germany/I;s/^UAE_/United Arab Emirates/I;s/^UK_/United Kingdom/I;s/^US_/United States/I;
+s/^AE_/United Arab Emirates/I;s/^GB_/United Kingdom/I;s/^AT_/Austria/I;s/^BE_/Belgium/I;s/^BG_/Bulgaria/I;s/^BR_/Brazil/I;
+s/^CH_/Switzerland/I;s/^CZ_/Czech Republic/I;s/^DK_/Denmark/I;s/^ES_/Spain/I;s/^FR_/France/I;s/^HK_/Hong Kong/I;s/^HU_/Hungary/I;
+s/^IE_/Ireland/I;s/^IL_/Israel/I;s/^IN_/India/I;s/^IT_/Italy/I;s/^JP_/Japan/I;s/^MX_/Mexico/I;s/^NL_/Netherlands/I;s/^NO_/Norway/I;s/^NZ_/New Zealand/I;
+s/^PL_/Poland/I;s/^RO_/Romania/I;s/^RS_/Serbia/I;s/^SE_/Sweden/I;s/^SG_/Singapore/I;s/^ZA_/South Africa/I;s/_/ /g;'
+}
+
+_pia_sed_reverse_country_codes(){
+	sed 's/Australia/AU/;s/Canada/CA/;s/Germany/DE/;s/United Kingdom/UK/;s/United States/US/;'
+}
+
+# provider_pia_get_server country_id country_name city_id city_name protocol vpn_type
+# Returns the OVPN filename stem (without .ovpn extension).
+provider_pia_get_server(){
+	_ps_countryname="$2"
+	_ps_cityname="$4"
+
+	_ps_stem="$(printf '%s' "$_ps_countryname" | _pia_sed_reverse_country_codes)"
+	if [ -n "$_ps_cityname" ]; then
+		_ps_stem="${_ps_stem}_${_ps_cityname}"
+	fi
+	_ps_stem="$(printf '%s' "$_ps_stem" | tr 'A-Z' 'a-z' | sed 's/ /_/g')"
+	printf '%s' "$_ps_stem"
+}
+
+# provider_pia_get_ovpn filename_stem protocol vpn_type
+# Extracts OVPN from the appropriate ZIP archive and prints to stdout.
+provider_pia_get_ovpn(){
+	_po_stem="$1"
+	_po_prot="$2"
+	_po_type="$3"
+	_po_prot_lc="$(printf '%s' "$_po_prot" | tr 'A-Z' 'a-z')"
+	_po_type_lc="$(printf '%s' "$_po_type" | tr 'A-Z' 'a-z')"
+	_po_archive="$OVPN_ARCHIVE_DIR/pia_${_po_prot_lc}_${_po_type_lc}.zip"
+
+	if [ ! -f "$_po_archive" ]; then
+		Print_Output true "PIA: Archive not found: $_po_archive" "$ERR"
+		return 1
+	fi
+
+	/opt/bin/7za e -bsp0 -bso0 "$_po_archive" -o/tmp "${_po_stem}.ovpn"
+	if [ ! -f "/tmp/${_po_stem}.ovpn" ]; then
+		Print_Output true "PIA: Could not extract ${_po_stem}.ovpn from archive" "$ERR"
+		return 1
+	fi
+	cat "/tmp/${_po_stem}.ovpn"
+	rm -f "/tmp/${_po_stem}.ovpn"
+}
+
+# provider_pia_get_comp
+provider_pia_get_comp(){
+	printf "no"
+}
+
+# provider_pia_get_hmac
+provider_pia_get_hmac(){
+	printf "1"
+}
+
+# provider_pia_get_short_name server_id addr
+# PIA uses the IP address as the identifier rather than a hostname.
+provider_pia_get_short_name(){
+	_sn_addr="$2"
+	if printf '%s' "$_sn_addr" | grep -q "-"; then
+		printf '%s' "$_sn_addr" | cut -f1 -d'.' \
+			| awk '{print toupper(substr($0,0,2))tolower(substr($0,3))}'
+	else
+		printf '%s' "$_sn_addr" | cut -f1 -d'.' \
+			| awk '{print toupper(substr($0,0,1))tolower(substr($0,2))}'
+	fi
+}
+
+# provider_pia_write_certs vpn_no ovpn_detail
+# Writes ca + crl; removes static, key, crt.
+provider_pia_write_certs(){
+	_wc_no="$1"
+	_wc_ovpn="$2"
+
+	_wc_ca="$(printf '%s' "$_wc_ovpn" | awk '/<ca>/{flag=1;next}/<\/ca>/{flag=0}flag' | sed '/^#/ d')"
+	[ -z "$_wc_ca" ] && Print_Output true "PIA: Error determining CA certificate" "$ERR" && return 1
+
+	_wc_crl="$(printf '%s' "$_wc_ovpn" | awk '/<crl-verify>/{flag=1;next}/<\/crl-verify>/{flag=0}flag' | sed '/^#/ d')"
+	[ -z "$_wc_crl" ] && Print_Output true "PIA: Error determining CRL" "$ERR" && return 1
+
+	printf '%s\n' "$_wc_ca"  > /jffs/openvpn/vpn_crt_client"${_wc_no}"_ca
+	printf '%s\n' "$_wc_crl" > /jffs/openvpn/vpn_crt_client"${_wc_no}"_crl
+	rm -f /jffs/openvpn/vpn_crt_client"${_wc_no}"_static
+	rm -f /jffs/openvpn/vpn_crt_client"${_wc_no}"_key
+	rm -f /jffs/openvpn/vpn_crt_client"${_wc_no}"_crt
+}
+
+# provider_pia_get_country_names
+# Reads pia_countrydata (flat list of OVPN stems), decodes country names.
+provider_pia_get_country_names(){
+	_pcd="$SCRIPT_DIR/pia_countrydata"
+	if [ ! -f "$_pcd" ]; then
+		Print_Output true "PIA: Country data cache missing — run refreshcacheddata" "$ERR"
+		return 1
+	fi
+	cat "$_pcd" | _pia_sed_country_codes_destructive \
+		| awk '{$1=$1;print}' \
+		| awk '{for(i=1;i<=NF;i++){ $i=toupper(substr($i,1,1)) substr($i,2) }}1' \
+		| sort -u
+}
+
+# provider_pia_get_country_id country_name
+# PIA does not use numeric country IDs.
+provider_pia_get_country_id(){
+	printf "0"
+}
+
+# provider_pia_get_city_count country_name
+provider_pia_get_city_count(){
+	_pcd="$SCRIPT_DIR/pia_countrydata"
+	cat "$_pcd" | _pia_sed_country_codes_destructive | sort | grep -c "$1"
+}
+
+# provider_pia_get_city_names country_name
+provider_pia_get_city_names(){
+	_pcd="$SCRIPT_DIR/pia_countrydata"
+	cat "$_pcd" | _pia_sed_country_codes | grep "$1" \
+		| sed "s/$1//" \
+		| awk '{$1=$1;print}' \
+		| awk '{for(i=1;i<=NF;i++){ $i=toupper(substr($i,1,1)) substr($i,2) }}1' \
+		| sort
+}
+
+# provider_pia_get_city_id country_name city_name
+# PIA does not use numeric city IDs.
+provider_pia_get_city_id(){
+	printf "0"
+}
+
+# provider_pia_country_required
+# Returns 0 — country selection is required for PIA.
+provider_pia_country_required(){
+	return 0
+}
+
+# provider_pia_city_required
+# Returns 0 — city selection is required for PIA.
+provider_pia_city_required(){
+	return 0
+}
+
+# provider_pia_get_types
+provider_pia_get_types(){
+	printf "Standard\nStrong\n"
+}
+
+# provider_pia_get_server_load desc
+# Not supported by PIA.
+provider_pia_get_server_load(){
+	printf ""
+}
+
+# provider_pia_refresh_cache
+# Downloads 4 PIA ZIP archives, compares with cached copies, updates pia_countrydata.
+provider_pia_refresh_cache(){
+	Print_Output true "PIA: Refreshing OpenVPN file archives..."
+
+	/usr/sbin/curl -fsL --retry 3 \
+		https://www.privateinternetaccess.com/openvpn/openvpn.zip \
+		-o /tmp/pia_udp_standard.zip
+	/usr/sbin/curl -fsL --retry 3 \
+		https://www.privateinternetaccess.com/openvpn/openvpn-tcp.zip \
+		-o /tmp/pia_tcp_standard.zip
+	/usr/sbin/curl -fsL --retry 3 \
+		https://www.privateinternetaccess.com/openvpn/openvpn-strong.zip \
+		-o /tmp/pia_udp_strong.zip
+	/usr/sbin/curl -fsL --retry 3 \
+		https://www.privateinternetaccess.com/openvpn/openvpn-strong-tcp.zip \
+		-o /tmp/pia_tcp_strong.zip
+
+	_prc_changed="$(CompareArchiveContents "/tmp/pia_udp_standard.zip /tmp/pia_tcp_standard.zip /tmp/pia_udp_strong.zip /tmp/pia_tcp_strong.zip")"
+
+	if [ "$_prc_changed" = "true" ]; then
+		/opt/bin/7za -ba l "$OVPN_ARCHIVE_DIR/pia_udp_standard.zip" -- "*.ovpn" \
+			| awk '{ for (i = 6; i <= NF; i++) { printf "%s ",$i } printf "\n"}' \
+			| sed 's/\.ovpn//' \
+			| sort \
+			| awk '{$1=$1;print}' \
+			> "$SCRIPT_DIR/pia_countrydata"
+		Print_Output true "PIA: Archives updated" "$PASS"
+	else
+		Print_Output true "PIA: Archives unchanged" "$WARN"
+	fi
+}
+
+# provider_pia_needs_cache
+# Returns 0 (needs refresh) if the standard UDP archive is missing.
+provider_pia_needs_cache(){
+	if [ ! -f "$OVPN_ARCHIVE_DIR/pia_udp_standard.zip" ]; then
+		return 0
+	fi
+	return 1
+}

--- a/providers/provider_template.sh
+++ b/providers/provider_template.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
-# Provider module template for vpnmgr
-# Copy this file and replace TEMPLATE with the provider name (lowercase).
+# Provider: TEMPLATE
+# Status: TEMPLATE
+# Description: Copy this file to providers/provider_<name>.sh and implement all functions.
 # All functions must be implemented — stubs return error by default.
 #
 # Naming convention: provider_PROVIDERNAME_FUNCTION

--- a/providers/provider_template.sh
+++ b/providers/provider_template.sh
@@ -1,0 +1,134 @@
+#!/bin/sh
+# Provider module template for vpnmgr
+# Copy this file and replace TEMPLATE with the provider name (lowercase).
+# All functions must be implemented — stubs return error by default.
+#
+# Naming convention: provider_PROVIDERNAME_FUNCTION
+#
+# Arguments are positional; providers must not use global state from vpnmgr.sh
+# except for SCRIPT_DIR, OVPN_ARCHIVE_DIR, SCRIPT_REPO and Print_Output.
+
+##########         Shellcheck directives     ##########
+# shellcheck disable=SC2039
+# shellcheck disable=SC3043
+#######################################################
+
+# provider_template_version
+# Prints a version string for this module.
+provider_template_version(){
+	printf "v0.0.0\n"
+}
+
+# provider_template_get_server country_id country_name city_id city_name protocol vpn_type
+# Returns a server identifier (hostname or filename stem) on stdout.
+# protocol: UDP or TCP
+# vpn_type: as returned by provider_template_get_types
+provider_template_get_server(){
+	Print_Output true "provider_template: get_server not implemented" "$ERR"
+	return 1
+}
+
+# provider_template_get_ovpn server_id protocol vpn_type
+# Downloads/extracts OVPN file contents and prints to stdout.
+provider_template_get_ovpn(){
+	Print_Output true "provider_template: get_ovpn not implemented" "$ERR"
+	return 1
+}
+
+# provider_template_get_comp
+# Prints the OpenVPN comp-lzo / compress value for this provider.
+provider_template_get_comp(){
+	printf "no\n"
+}
+
+# provider_template_get_hmac
+# Prints the HMAC authentication mode value (0/1/2/3).
+provider_template_get_hmac(){
+	printf "1\n"
+}
+
+# provider_template_get_short_name server_id addr
+# Returns a short display name derived from server_id and/or addr.
+provider_template_get_short_name(){
+	Print_Output true "provider_template: get_short_name not implemented" "$ERR"
+	return 1
+}
+
+# provider_template_write_certs vpn_no ovpn_detail
+# Writes CA/CRL/crt/key/static files to /jffs/openvpn/ for vpn client vpn_no.
+# ovpn_detail: full text of the OVPN file (passed as $2)
+provider_template_write_certs(){
+	Print_Output true "provider_template: write_certs not implemented" "$ERR"
+	return 1
+}
+
+# provider_template_get_country_names
+# Prints a newline-separated list of country names available for this provider.
+provider_template_get_country_names(){
+	Print_Output true "provider_template: get_country_names not implemented" "$ERR"
+	return 1
+}
+
+# provider_template_get_country_id country_name
+# Prints the numeric country ID for country_name (or "0" if not applicable).
+provider_template_get_country_id(){
+	printf "0\n"
+}
+
+# provider_template_get_city_count country_name
+# Prints the number of cities available for country_name.
+provider_template_get_city_count(){
+	printf "0\n"
+}
+
+# provider_template_get_city_names country_name
+# Prints a newline-separated list of city names for country_name.
+provider_template_get_city_names(){
+	Print_Output true "provider_template: get_city_names not implemented" "$ERR"
+	return 1
+}
+
+# provider_template_get_city_id country_name city_name
+# Prints the numeric city ID (or "0" if not applicable).
+provider_template_get_city_id(){
+	printf "0\n"
+}
+
+# provider_template_country_required
+# Returns 0 if a country selection is required, 1 if optional.
+provider_template_country_required(){
+	return 0
+}
+
+# provider_template_city_required
+# Returns 0 if a city selection is required, 1 if optional.
+provider_template_city_required(){
+	return 0
+}
+
+# provider_template_get_types
+# Prints a newline-separated list of VPN type display names.
+provider_template_get_types(){
+	printf "Standard\n"
+}
+
+# provider_template_get_server_load desc
+# Prints the current server load percentage string, or "" if unsupported.
+# desc: the nvram vpn_clientX_desc value
+provider_template_get_server_load(){
+	printf ""
+}
+
+# provider_template_refresh_cache
+# Downloads/updates any cached data files required by this provider.
+# Returns 0 on success, 1 on failure.
+provider_template_refresh_cache(){
+	Print_Output true "provider_template: refresh_cache not implemented" "$ERR"
+	return 1
+}
+
+# provider_template_needs_cache
+# Returns 0 if cached data is missing and a refresh is needed, 1 if cache is present.
+provider_template_needs_cache(){
+	return 0
+}

--- a/providers/provider_wevpn.sh
+++ b/providers/provider_wevpn.sh
@@ -1,0 +1,179 @@
+#!/bin/sh
+# WeVPN provider module for vpnmgr
+# Status: DEPRECATED — WeVPN is no longer operational
+#
+# This module is kept for historical reference only. All network operations
+# will fail or print a deprecation notice. Do not use for new configurations.
+
+##########         Shellcheck directives     ##########
+# shellcheck disable=SC2039
+# shellcheck disable=SC3043
+#######################################################
+
+_WEVPN_DEPRECATED_MSG="WeVPN is no longer operational. This provider is deprecated."
+
+provider_wevpn_version(){
+	printf "v1.0.0\n"
+}
+
+# Internal country code mappings for WeVPN
+_wevpn_sed_country_codes_destructive(){
+	sed 's/ /_/g;s/^AU_.*/Australia/I;s/^CA_.*/Canada/I;s/^DE_.*/Germany/I;s/^UAE_.*/United Arab Emirates/I;s/^UK_.*/United Kingdom/I;s/^US_.*/United States/I;
+s/^AE_.*/United Arab Emirates/I;s/^GB_.*/United Kingdom/I;s/^AT_.*/Austria/I;s/^BE_.*/Belgium/I;s/^BG_.*/Bulgaria/I;s/^BR_.*/Brazil/I;
+s/^CH_.*/Switzerland/I;s/^CZ_.*/Czech Republic/I;s/^DK_.*/Denmark/I;s/^ES_.*/Spain/I;s/^FR_.*/France/I;s/^HK_.*/Hong Kong/I;s/^HU_.*/Hungary/I;
+s/^IE_.*/Ireland/I;s/^IL_.*/Israel/I;s/^IN_.*/India/I;s/^IT_.*/Italy/I;s/^JP_.*/Japan/I;s/^MX_.*/Mexico/I;s/^NL_.*/Netherlands/I;s/^NO_.*/Norway/I;s/^NZ_.*/New Zealand/I;
+s/^PL_.*/Poland/I;s/^RO_.*/Romania/I;s/^RS_.*/Serbia/I;s/^SE_.*/Sweden/I;s/^SG_.*/Singapore/I;s/^ZA_.*/South Africa/I;s/_/ /g;'
+}
+
+_wevpn_sed_country_codes(){
+	sed 's/ /_/g;s/^AU_/Australia/I;s/^CA_/Canada/I;s/^DE_/Germany/I;s/^UAE_/United Arab Emirates/I;s/^UK_/United Kingdom/I;s/^US_/United States/I;
+s/^AE_/United Arab Emirates/I;s/^GB_/United Kingdom/I;s/^AT_/Austria/I;s/^BE_/Belgium/I;s/^BG_/Bulgaria/I;s/^BR_/Brazil/I;
+s/^CH_/Switzerland/I;s/^CZ_/Czech Republic/I;s/^DK_/Denmark/I;s/^ES_/Spain/I;s/^FR_/France/I;s/^HK_/Hong Kong/I;s/^HU_/Hungary/I;
+s/^IE_/Ireland/I;s/^IL_/Israel/I;s/^IN_/India/I;s/^IT_/Italy/I;s/^JP_/Japan/I;s/^MX_/Mexico/I;s/^NL_/Netherlands/I;s/^NO_/Norway/I;s/^NZ_/New Zealand/I;
+s/^PL_/Poland/I;s/^RO_/Romania/I;s/^RS_/Serbia/I;s/^SE_/Sweden/I;s/^SG_/Singapore/I;s/^ZA_/South Africa/I;s/_/ /g;'
+}
+
+_wevpn_sed_reverse_country_codes(){
+	sed 's/Australia/AU/;s/Canada/CA/;s/Germany/DE/;s/United States/US/;s/United Arab Emirates/AE/;s/United Kingdom/GB/;
+s/Austria/AT/;s/Belgium/BE/;s/Bulgaria/BG/;s/Brazil/BR/;s/Switzerland/CH/;s/Czech Republic/CZ/;s/Denmark/DK/;s/Spain/ES/;s/France/FR/;
+s/Hong Kong/HK/;s/Hungary/HU/;s/Ireland/IE/;s/Israel/IL/;s/India/IN/;s/Italy/IT/;s/Japan/JP/;s/Mexico/MX/;s/Netherlands/NL/;s/Norway/NO/;s/New Zealand/NZ/;
+s/Poland/PL/;s/Romania/RO/;s/Serbia/RS/;s/Sweden/SE/;s/Singapore/SG/;s/South Africa/ZA/;s/_/ /g;'
+}
+
+# provider_wevpn_get_server country_id country_name city_id city_name protocol vpn_type
+# Returns the OVPN filename stem.
+provider_wevpn_get_server(){
+	_ws_countryname="$2"
+	_ws_cityname="$4"
+	_ws_prot="$5"
+
+	_ws_stem="$(printf '%s' "$_ws_countryname" | _wevpn_sed_reverse_country_codes)"'_'"$(printf '%s' "$_ws_cityname" | tr 'A-Z' 'a-z')-${_ws_prot}"
+	printf '%s' "$_ws_stem"
+}
+
+# provider_wevpn_get_ovpn filename_stem protocol vpn_type
+# WeVPN is deprecated — prints a clear error and returns 1.
+provider_wevpn_get_ovpn(){
+	Print_Output true "WeVPN: $_WEVPN_DEPRECATED_MSG" "$ERR"
+	return 1
+}
+
+# provider_wevpn_get_comp
+provider_wevpn_get_comp(){
+	printf -- "-1"
+}
+
+# provider_wevpn_get_hmac
+provider_wevpn_get_hmac(){
+	printf "3"
+}
+
+# provider_wevpn_get_short_name server_id addr
+provider_wevpn_get_short_name(){
+	_sn_addr="$2"
+	printf '%s' "$_sn_addr" | cut -f1 -d'.' \
+		| awk '{print toupper(substr($0,0,1))tolower(substr($0,2))}'
+}
+
+# provider_wevpn_write_certs vpn_no ovpn_detail
+# Writes ca + crt + static (tls-crypt) + key; removes crl.
+provider_wevpn_write_certs(){
+	_wc_no="$1"
+	_wc_ovpn="$2"
+
+	_wc_ca="$(printf '%s' "$_wc_ovpn" | awk '/<ca>/{flag=1;next}/<\/ca>/{flag=0}flag' | sed '/^#/ d')"
+	[ -z "$_wc_ca" ] && Print_Output true "WeVPN: Error determining CA certificate" "$ERR" && return 1
+
+	_wc_crt="$(printf '%s' "$_wc_ovpn" | awk '/<cert>/{flag=1;next}/<\/cert>/{flag=0}flag' | sed '/^#/ d')"
+	[ -z "$_wc_crt" ] && Print_Output true "WeVPN: Error determining client cert" "$ERR" && return 1
+
+	_wc_static="$(printf '%s' "$_wc_ovpn" | awk '/<tls-crypt>/{flag=1;next}/<\/tls-crypt>/{flag=0}flag' | sed '/^#/ d')"
+	[ -z "$_wc_static" ] && Print_Output true "WeVPN: Error determining static (tls-crypt) key" "$ERR" && return 1
+
+	_wc_key="$(printf '%s' "$_wc_ovpn" | awk '/<key>/{flag=1;next}/<\/key>/{flag=0}flag' | sed '/^#/ d')"
+	[ -z "$_wc_key" ] && Print_Output true "WeVPN: Error determining client key" "$ERR" && return 1
+
+	printf '%s\n' "$_wc_ca"     > /jffs/openvpn/vpn_crt_client"${_wc_no}"_ca
+	printf '%s\n' "$_wc_crt"    > /jffs/openvpn/vpn_crt_client"${_wc_no}"_crt
+	printf '%s\n' "$_wc_static" > /jffs/openvpn/vpn_crt_client"${_wc_no}"_static
+	printf '%s\n' "$_wc_key"    > /jffs/openvpn/vpn_crt_client"${_wc_no}"_key
+	rm -f /jffs/openvpn/vpn_crt_client"${_wc_no}"_crl
+}
+
+# provider_wevpn_get_country_names
+provider_wevpn_get_country_names(){
+	_wcd="$SCRIPT_DIR/wevpn_countrydata"
+	if [ ! -f "$_wcd" ]; then
+		Print_Output true "WeVPN: Country data cache missing" "$ERR"
+		return 1
+	fi
+	cat "$_wcd" | _wevpn_sed_country_codes_destructive \
+		| awk '{$1=$1;print}' \
+		| awk '{for(i=1;i<=NF;i++){ $i=toupper(substr($i,1,1)) substr($i,2) }}1' \
+		| sort -u
+}
+
+# provider_wevpn_get_country_id country_name
+# WeVPN does not use numeric country IDs.
+provider_wevpn_get_country_id(){
+	printf "0"
+}
+
+# provider_wevpn_get_city_count country_name
+provider_wevpn_get_city_count(){
+	_wcd="$SCRIPT_DIR/wevpn_countrydata"
+	cat "$_wcd" | _wevpn_sed_country_codes_destructive | sort | grep -c "$1"
+}
+
+# provider_wevpn_get_city_names country_name
+provider_wevpn_get_city_names(){
+	_wcd="$SCRIPT_DIR/wevpn_countrydata"
+	cat "$_wcd" | _wevpn_sed_country_codes | grep "$1" \
+		| sed "s/$1//" \
+		| awk '{$1=$1;print}' \
+		| awk '{for(i=1;i<=NF;i++){ $i=toupper(substr($i,1,1)) substr($i,2) }}1' \
+		| sort
+}
+
+# provider_wevpn_get_city_id country_name city_name
+# WeVPN does not use numeric city IDs.
+provider_wevpn_get_city_id(){
+	printf "0"
+}
+
+# provider_wevpn_country_required
+# Returns 0 — country selection is required.
+provider_wevpn_country_required(){
+	return 0
+}
+
+# provider_wevpn_city_required
+# Returns 0 — city selection is required.
+provider_wevpn_city_required(){
+	return 0
+}
+
+# provider_wevpn_get_types
+provider_wevpn_get_types(){
+	printf "Standard\n"
+}
+
+# provider_wevpn_get_server_load desc
+# Not supported.
+provider_wevpn_get_server_load(){
+	printf ""
+}
+
+# provider_wevpn_refresh_cache
+# Deprecated — WeVPN archives are no longer available.
+provider_wevpn_refresh_cache(){
+	Print_Output true "WeVPN: $_WEVPN_DEPRECATED_MSG" "$ERR"
+	Print_Output true "WeVPN: Cache refresh is not possible for a deprecated provider" "$WARN"
+	return 1
+}
+
+# provider_wevpn_needs_cache
+# Returns 0 always (cache will never be satisfiable for a deprecated provider).
+provider_wevpn_needs_cache(){
+	return 0
+}

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+# smoke-test.sh
+#
+# Validates vpnmgr.sh and provider modules: syntax, shellcheck, provider contract
+# completeness, repo hygiene, and attribution.
+#
+# Usage:
+#   ./scripts/smoke-test.sh
+#   ./scripts/smoke-test.sh --offline   (alias — all tests are offline)
+#
+# Exit code: 0 = all tests passed, 1 = one or more failures.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+pass()    { echo -e "  ${GREEN}✓${NC} $1"; PASS=$((PASS + 1)); }
+fail()    { echo -e "  ${RED}✗${NC} $1"; FAIL=$((FAIL + 1)); }
+warn()    { echo -e "  ${YELLOW}!${NC} $1"; }
+section() { echo -e "\n${BOLD}${BLUE}$1${NC}"; }
+
+PASS=0
+FAIL=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo -e "\n${BOLD}Smoke Test — vpnmgr${NC}"
+echo "Repo: ${REPO_ROOT}"
+
+# ---------------------------------------------------------------------------
+# Section 1: Syntax + shellcheck on all shell scripts
+#
+# These are ash (POSIX sh) scripts. sh -n checks syntax; shellcheck
+# is run with --shell=sh to match the actual target environment.
+# ---------------------------------------------------------------------------
+section "1. Syntax and static analysis"
+
+SHELL_SCRIPTS=(vpnmgr.sh)
+
+while IFS= read -r -d '' f; do
+    SHELL_SCRIPTS+=("${f#${REPO_ROOT}/}")
+done < <(find "${REPO_ROOT}/providers" -name '*.sh' -print0 2>/dev/null | sort -z)
+
+SHELLCHECK_AVAILABLE=false
+if command -v shellcheck &>/dev/null; then
+    SHELLCHECK_AVAILABLE=true
+fi
+
+for script in "${SHELL_SCRIPTS[@]}"; do
+    if [[ ! -f "$script" ]]; then
+        fail "${script} — file not found"
+        continue
+    fi
+
+    if sh -n "$script" 2>/dev/null; then
+        pass "${script} — sh -n"
+    else
+        fail "${script} — sh -n: $(sh -n "$script" 2>&1)"
+        continue
+    fi
+
+    if [[ "$SHELLCHECK_AVAILABLE" == true ]]; then
+        sc_out=$(shellcheck --shell=sh --severity=warning "$script" 2>&1) || true
+        if [[ -z "$sc_out" ]]; then
+            pass "${script} — shellcheck"
+        else
+            fail "${script} — shellcheck"
+            echo "$sc_out" | sed 's/^/    /'
+        fi
+    fi
+done
+
+if [[ "$SHELLCHECK_AVAILABLE" == false ]]; then
+    warn "shellcheck not found — skipping static analysis (install: apt install shellcheck)"
+fi
+
+# ---------------------------------------------------------------------------
+# Section 2: Provider contract completeness
+#
+# The core dispatches to these 17 functions for every configured provider.
+# Verify each non-template provider module implements all of them.
+# ---------------------------------------------------------------------------
+section "2. Provider contract"
+
+REQUIRED_FUNCS=(
+    version
+    get_server
+    get_ovpn
+    get_comp
+    get_hmac
+    get_short_name
+    write_certs
+    get_country_names
+    get_country_id
+    get_city_count
+    get_city_names
+    get_city_id
+    country_required
+    city_required
+    get_types
+    get_server_load
+    refresh_cache
+)
+
+if [[ ! -d "${REPO_ROOT}/providers" ]]; then
+    warn "providers/ directory not found — skipping contract checks"
+else
+    provider_count=0
+    while IFS= read -r -d '' pfile; do
+        pname=$(basename "$pfile" .sh | sed 's/^provider_//')
+        [[ "$pname" == "template" ]] && continue
+        provider_count=$((provider_count + 1))
+        for fn in "${REQUIRED_FUNCS[@]}"; do
+            fqfn="provider_${pname}_${fn}"
+            if grep -q "^${fqfn}(){" "$pfile" || grep -q "^${fqfn}() {" "$pfile"; then
+                pass "${pname}: ${fn}()"
+            else
+                fail "${pname}: missing ${fqfn}()"
+            fi
+        done
+    done < <(find "${REPO_ROOT}/providers" -name 'provider_*.sh' -print0 | sort -z)
+
+    if [[ $provider_count -eq 0 ]]; then
+        warn "No non-template provider modules found in providers/"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Section 3: Repo hygiene — no provider config files committed
+# ---------------------------------------------------------------------------
+section "3. Repo hygiene"
+
+for pat in '*.ovpn' '*.zip' '*.p12' '*.pem'; do
+    hits=$(git -C "${REPO_ROOT}" ls-files "$pat" 2>/dev/null || true)
+    if [[ -z "$hits" ]]; then
+        pass "No ${pat} files committed"
+    else
+        fail "Committed ${pat} files found (must download at runtime, never commit):"
+        echo "$hits" | sed 's/^/    /'
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Section 4: Core cleanliness — no inline provider API URLs in vpnmgr.sh
+#
+# Provider-specific API endpoints belong in provider modules, not the core.
+# ---------------------------------------------------------------------------
+section "4. Core script cleanliness"
+
+for pat in 'api\.nordvpn\.com' 'nordcdn\.com' 'privateinternetaccess\.com' 'wevpn\.com'; do
+    hits=$(grep -n "$pat" "${REPO_ROOT}/vpnmgr.sh" 2>/dev/null || true)
+    if [[ -z "$hits" ]]; then
+        pass "vpnmgr.sh: no inline ${pat}"
+    else
+        fail "vpnmgr.sh: provider-specific URL found (should be in provider module):"
+        echo "$hits" | sed 's/^/    /'
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Section 5: Attribution — SCRIPT_REPO points to h0me5k1n
+# ---------------------------------------------------------------------------
+section "5. Attribution"
+
+if grep -q 'SCRIPT_REPO=.*h0me5k1n' "${REPO_ROOT}/vpnmgr.sh"; then
+    repo_val=$(grep 'SCRIPT_REPO=' "${REPO_ROOT}/vpnmgr.sh" | head -1 | sed 's/.*="\(.*\)"/\1/')
+    pass "SCRIPT_REPO → ${repo_val}"
+else
+    actual=$(grep 'SCRIPT_REPO=' "${REPO_ROOT}/vpnmgr.sh" | head -1 || echo "(not found)")
+    fail "SCRIPT_REPO does not point to h0me5k1n — got: ${actual}"
+fi
+
+# ---------------------------------------------------------------------------
+# Section 6: Provider status headers
+# ---------------------------------------------------------------------------
+section "6. Provider status headers"
+
+if [[ -d "${REPO_ROOT}/providers" ]]; then
+    while IFS= read -r -d '' pfile; do
+        pname=$(basename "$pfile" .sh | sed 's/^provider_//')
+        if grep -q '^# Status:' "$pfile"; then
+            status=$(grep '^# Status:' "$pfile" | head -1 | sed 's/^# Status: *//')
+            pass "${pname}: Status: ${status}"
+        else
+            fail "${pname}: missing '# Status:' header"
+        fi
+    done < <(find "${REPO_ROOT}/providers" -name 'provider_*.sh' -print0 | sort -z)
+fi
+
+# ---------------------------------------------------------------------------
+# Section 7: .gitignore coverage
+# ---------------------------------------------------------------------------
+section "7. .gitignore coverage"
+
+for pat in '*.ovpn' '*.zip' '*.p12' '*.pem'; do
+    if grep -qF "$pat" "${REPO_ROOT}/.gitignore" 2>/dev/null; then
+        pass ".gitignore: ${pat}"
+    else
+        fail ".gitignore missing ${pat} — provider config files could be accidentally committed"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Section 8: WebUI files — TODO (Phase 4)
+#
+# These checks are stubbed out because vpnmgr_www.js still contains ES6+
+# constructs from jackyaz's original code (let, const, arrow functions).
+# Enable each check after the Phase 4 WebUI rework cleans them up.
+# ---------------------------------------------------------------------------
+section "8. WebUI files (TODO — Phase 4)"
+
+WEBUI_JS="${REPO_ROOT}/vpnmgr_www.js"
+WEBUI_CSS="${REPO_ROOT}/vpnmgr_www.css"
+WEBUI_ASP="${REPO_ROOT}/vpnmgr_www.asp"
+
+# TODO: JS syntax check
+# Requires: node (available on ubuntu-latest)
+# Enable once Phase 4 is complete.
+#   if node --check "$WEBUI_JS" 2>/dev/null; then
+#       pass "vpnmgr_www.js — node syntax"
+#   else
+#       fail "vpnmgr_www.js — node syntax: $(node --check "$WEBUI_JS" 2>&1)"
+#   fi
+
+# TODO: No ES6+ in the JS file
+# Router httpd may not support ES6; jackyaz's code has let/const/arrow functions
+# that must be replaced with var/function in Phase 4.
+# Enable once Phase 4 is complete.
+#   for pat in '\blet ' '\bconst ' '=>' '`' '\bfetch('; do
+#       hits=$(grep -n "$pat" "$WEBUI_JS" || true)
+#       if [[ -z "$hits" ]]; then
+#           pass "vpnmgr_www.js: no ES6+ pattern (${pat})"
+#       else
+#           fail "vpnmgr_www.js: ES6+ pattern '${pat}' found (not safe on router httpd):"
+#           echo "$hits" | sed 's/^/    /'
+#       fi
+#   done
+
+# TODO: jQuery uses $j not $ (noConflict mode — $ clashes with Merlin's prototype.js)
+# Enable once Phase 4 is complete.
+#   bare_dollar=$(grep -n '[^$a-zA-Z0-9]\$(' "$WEBUI_JS" | grep -v '\$j(' || true)
+#   if [[ -z "$bare_dollar" ]]; then
+#       pass "vpnmgr_www.js: jQuery calls use \$j (noConflict)"
+#   else
+#       fail "vpnmgr_www.js: bare \$() found — must use \$j() in noConflict mode:"
+#       echo "$bare_dollar" | sed 's/^/    /'
+#   fi
+
+# TODO: No hardcoded provider country/server lists in JS
+# After Phase 4 these must be loaded dynamically from /ext/vpnmgr/countries_*.htm
+# Enable once Phase 4 is complete.
+#   for var in nordvpncountries piacountries wevpncountries; do
+#       if grep -q "$var" "$WEBUI_JS"; then
+#           fail "vpnmgr_www.js: hardcoded ${var} array found — must be loaded dynamically"
+#       else
+#           pass "vpnmgr_www.js: no hardcoded ${var}"
+#       fi
+#   done
+
+# TODO: CSS syntax check
+# Requires: node + css npm package, or stylelint
+# Enable once Phase 4 is complete.
+#   node -e "require('fs'); require('css').parse(require('fs').readFileSync('$WEBUI_CSS','utf8'))" \
+#       && pass "vpnmgr_www.css — css parse" \
+#       || fail "vpnmgr_www.css — css parse error"
+
+# TODO: ASP/HTML structure check
+# Strip <% %> blocks and run through tidy (available on ubuntu-latest)
+# Enable once Phase 4 is complete.
+#   sed 's/<%[^%]*%>//g' "$WEBUI_ASP" \
+#       | tidy -errors -quiet --show-warnings no 2>&1 | grep -c 'Error' \
+#       | { read c; [[ "$c" -eq 0 ]] && pass "vpnmgr_www.asp — tidy HTML" \
+#           || fail "vpnmgr_www.asp — tidy found ${c} HTML error(s)"; }
+
+warn "WebUI checks skipped — vpnmgr_www.js has ES6+ from jackyaz; enable after Phase 4 rework"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+TOTAL=$((PASS + FAIL))
+echo ""
+echo -e "${BOLD}─────────────────────────────────────────${NC}"
+if [[ $FAIL -eq 0 ]]; then
+    echo -e "${GREEN}${BOLD}All ${TOTAL} tests passed.${NC}"
+else
+    echo -e "${RED}${BOLD}${FAIL} of ${TOTAL} tests failed.${NC}"
+fi
+echo -e "${BOLD}─────────────────────────────────────────${NC}"
+echo ""
+
+[[ $FAIL -eq 0 ]]

--- a/vpnmgr.sh
+++ b/vpnmgr.sh
@@ -9,12 +9,14 @@
 ##          | |                        __/ |         ##
 ##          |_|                       |___/          ##
 ##                                                   ##
-##         https://github.com/jackyaz/vpnmgr         ##
-##                forked from h0me5k1n               ##
+##       https://github.com/h0me5k1n/vpnmgr          ##
+##     Originally by h0me5k1n, expanded by jackyaz   ##
 #######################################################
 
 ##########         Shellcheck directives     ##########
+# shellcheck disable=SC1090
 # shellcheck disable=SC2009
+# shellcheck disable=SC2317
 # shellcheck disable=SC2016
 # shellcheck disable=SC2018
 # shellcheck disable=SC2019
@@ -29,10 +31,11 @@
 readonly SCRIPT_NAME="vpnmgr"
 readonly SCRIPT_VERSION="v2.3.2"
 SCRIPT_BRANCH="master"
-SCRIPT_REPO="https://raw.githubusercontent.com/jackyaz/$SCRIPT_NAME/$SCRIPT_BRANCH"
+SCRIPT_REPO="https://raw.githubusercontent.com/h0me5k1n/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME.d"
 readonly SCRIPT_CONF="$SCRIPT_DIR/config"
 readonly OVPN_ARCHIVE_DIR="$SCRIPT_DIR/ovpn"
+readonly PROVIDERS_DIR="$SCRIPT_DIR/providers"
 readonly SCRIPT_WEBPAGE_DIR="$(readlink /www/user)"
 readonly SCRIPT_WEB_DIR="$SCRIPT_WEBPAGE_DIR/$SCRIPT_NAME"
 readonly SHARED_DIR="/jffs/addons/shared-jy"
@@ -68,6 +71,18 @@ Print_Output(){
 		logger -t "$SCRIPT_NAME" "$2"
 	fi
 	printf "${BOLD}${3}%s${CLEARFORMAT}\\n\\n" "$2"
+}
+
+Load_Provider(){
+	_lp_provider="$1"
+	_lp_script="${PROVIDERS_DIR}/provider_${_lp_provider}.sh"
+	if [ -f "$_lp_script" ]; then
+		. "$_lp_script"
+		return 0
+	else
+		Print_Output true "Provider module not found: $_lp_provider (run vpnmgr update)" "$ERR"
+		return 1
+	fi
 }
 
 Firmware_Version_Check(){
@@ -153,7 +168,7 @@ Update_Check(){
 	echo 'var updatestatus = "InProgress";' > "$SCRIPT_WEB_DIR/detect_update.js"
 	doupdate="false"
 	localver=$(grep "SCRIPT_VERSION=" "/jffs/scripts/$SCRIPT_NAME" | grep -m1 -oE 'v[0-9]{1,2}([.][0-9]{1,2})([.][0-9]{1,2})')
-	/usr/sbin/curl -fsL --retry 3 "$SCRIPT_REPO/$SCRIPT_NAME.sh" | grep -qF "jackyaz" || { Print_Output true "404 error detected - stopping update" "$ERR"; return 1; }
+	/usr/sbin/curl -fsL --retry 3 "$SCRIPT_REPO/$SCRIPT_NAME.sh" | grep -qF "h0me5k1n" || { Print_Output true "404 error detected - stopping update" "$ERR"; return 1; }
 	serverver=$(/usr/sbin/curl -fsL --retry 3 "$SCRIPT_REPO/$SCRIPT_NAME.sh" | grep "SCRIPT_VERSION=" | grep -m1 -oE 'v[0-9]{1,2}([.][0-9]{1,2})([.][0-9]{1,2})')
 	if [ "$localver" != "$serverver" ]; then
 		doupdate="version"
@@ -508,7 +523,11 @@ Create_Dirs(){
 	if [ ! -d "$OVPN_ARCHIVE_DIR" ]; then
 		mkdir -p "$OVPN_ARCHIVE_DIR"
 	fi
-	
+
+	if [ ! -d "$PROVIDERS_DIR" ]; then
+		mkdir -p "$PROVIDERS_DIR"
+	fi
+
 	if [ ! -d "$SHARED_DIR" ]; then
 		mkdir -p "$SHARED_DIR"
 	fi
@@ -536,6 +555,31 @@ Create_Symlinks(){
 	if [ ! -d "$SHARED_WEB_DIR" ]; then
 		ln -s "$SHARED_DIR" "$SHARED_WEB_DIR" 2>/dev/null
 	fi
+}
+
+Install_Providers(){
+	mkdir -p "$PROVIDERS_DIR"
+	for provider in nordvpn pia wevpn; do
+		/usr/sbin/curl -fsL --retry 3 \
+			"$SCRIPT_REPO/providers/provider_${provider}.sh" \
+			-o "$PROVIDERS_DIR/provider_${provider}.sh"
+		chmod 0755 "$PROVIDERS_DIR/provider_${provider}.sh"
+	done
+}
+
+Refresh_Provider_Cache(){
+	configured_providers=""
+	for i in 1 2 3 4 5; do
+		prov="$(grep "vpn${i}_provider" "$SCRIPT_CONF" | cut -f2 -d"=" | tr 'A-Z' 'a-z')"
+		if [ -n "$prov" ] && ! printf '%s' "$configured_providers" | grep -qF "$prov"; then
+			configured_providers="${configured_providers} ${prov}"
+		fi
+	done
+	for prov in $configured_providers; do
+		if Load_Provider "$prov"; then
+			"provider_${prov}_refresh_cache"
+		fi
+	done
 }
 
 Conf_Exists(){
@@ -573,116 +617,8 @@ Conf_Exists(){
 	fi
 }
 
-# use to create content of vJSON variable; $1 VPN type, $2 VPN protocol, $3 country id
-getRecommendedServers(){
-	curlstring="https://api.nordvpn.com/v1/servers/recommendations?filters\[servers_groups\]\[identifier\]=${1}&filters\[servers_technologies\]\[identifier\]=${2}"
-	if [ "$3" -ne 0 ]; then
-		curlstring="${curlstring}&filters\[country_id\]=$3"
-	fi
-	curlstring="${curlstring}&limit=1"
-	/usr/sbin/curl -fsL --retry 3 "$curlstring" | jq -r -e '.[] // empty'
-}
-
-getServerLoad(){
-	curlstring="https://api.nordvpn.com/server/stats/"
-	serverhostname="$(echo "$1" | cut -f2 -d ' ' | tr "A-Z" "a-z").nordvpn.com"
-	/usr/sbin/curl -fsL --retry 3 "$curlstring$serverhostname" | jq -r -e '.percent // "Unknown"'
-}
-
-getServersforCity(){
-	/usr/sbin/curl -fsL --retry 3 "https://api.nordvpn.com/v1/servers/recommendations?filters\[servers_groups\]\[identifier\]=${1}&filters\[servers_technologies\]\[identifier\]=${2}&filters\[country_id\]=${3}&limit=2500" | jq -r -e ' [ .[] | select(.locations[].country.city.id=='"$4"')][0] // empty'
-}
-
-getCountryData(){
-	Print_Output true "Refreshing NordVPN country data..."
-	/usr/sbin/curl -fsL --retry 3 "https://api.nordvpn.com/v1/servers/countries" | jq -r > /tmp/nordvpn_countrydata
-	countrydata="$(cat /tmp/nordvpn_countrydata)"
-	[ -z "$countrydata" ] && Print_Output true "Error, country data from NordVPN failed to download" "$ERR" && return 1
-	if [ -f "$SCRIPT_DIR/nordvpn_countrydata" ]; then
-		if ! diff -q /tmp/nordvpn_countrydata "$SCRIPT_DIR/nordvpn_countrydata" >/dev/null 2>&1; then
-			mv /tmp/nordvpn_countrydata "$SCRIPT_DIR/nordvpn_countrydata"
-			Print_Output true "Changes detected in NordVPN country data found, updating now" "$PASS"
-			Create_Symlinks
-		else
-			rm -f /tmp/nordvpn_countrydata
-			Print_Output true "No changes in NordVPN country data" "$WARN"
-		fi
-	else
-		mv /tmp/nordvpn_countrydata "$SCRIPT_DIR/nordvpn_countrydata"
-		Create_Symlinks
-		Print_Output true "No previous NordVPN country data found, updating now" "$PASS"
-	fi
-}
-
-sedCountryCodesDestructive(){
-	sed 's/ /_/g;s/^AU_.*/Australia/I;s/^CA_.*/Canada/I;s/^DE_.*/Germany/I;s/^UAE_.*/United Arab Emirates/I;s/^UK_.*/United Kingdom/I;s/^US_.*/United States/I;
-s/^AE_.*/United Arab Emirates/I;s/^GB_.*/United Kingdom/I;s/^AT_.*/Austria/I;s/^BE_.*/Belgium/I;s/^BG_.*/Bulgaria/I;s/^BR_.*/Brazil/I;
-s/^CH_.*/Switzerland/I;s/^CZ_.*/Czech Republic/I;s/^DK_.*/Denmark/I;s/^ES_.*/Spain/I;s/^FR_.*/France/I;s/^HK_.*/Hong Kong/I;s/^HU_.*/Hungary/I;
-s/^IE_.*/Ireland/I;s/^IL_.*/Israel/I;s/^IN_.*/India/I;s/^IT_.*/Italy/I;s/^JP_.*/Japan/I;s/^MX_.*/Mexico/I;s/^NL_.*/Netherlands/I;s/^NO_.*/Norway/I;s/^NZ_.*/New Zealand/I;
-s/^PL_.*/Poland/I;s/^RO_.*/Romania/I;s/^RS_.*/Serbia/I;s/^SE_.*/Sweden/I;s/^SG_.*/Singapore/I;s/^ZA_.*/South Africa/I;s/_/ /g;'
-}
-
-sedCountryCodes(){
-	sed 's/ /_/g;s/^AU_/Australia/I;s/^CA_/Canada/I;s/^DE_/Germany/I;s/^UAE_/United Arab Emirates/I;s/^UK_/United Kingdom/I;s/^US_/United States/I;
-s/^AE_/United Arab Emirates/I;s/^GB_/United Kingdom/I;s/^AT_/Austria/I;s/^BE_/Belgium/I;s/^BG_/Bulgaria/I;s/^BR_/Brazil/I;
-s/^CH_/Switzerland/I;s/^CZ_/Czech Republic/I;s/^DK_/Denmark/I;s/^ES_/Spain/I;s/^FR_/France/I;s/^HK_/Hong Kong/I;s/^HU_/Hungary/I;
-s/^IE_/Ireland/I;s/^IL_/Israel/I;s/^IN_/India/I;s/^IT_/Italy/I;s/^JP_/Japan/I;s/^MX_/Mexico/I;s/^NL_/Netherlands/I;s/^NO_/Norway/I;s/^NZ_/New Zealand/I;
-s/^PL_/Poland/I;s/^RO_/Romania/I;s/^RS_/Serbia/I;s/^SE_/Sweden/I;s/^SG_/Singapore/I;s/^ZA_/South Africa/I;s/_/ /g;'
-}
-
-sedReverseCountryCodesPIA(){
-	sed 's/Australia/AU/;s/Canada/CA/;s/Germany/DE/;s/United Kingdom/UK/;s/United States/US/;'
-}
-
-sedReverseCountryCodesWeVPN(){
-	sed 's/Australia/AU/;s/Canada/CA/;s/Germany/DE/;s/United States/US/;s/United Arab Emirates/AE/;s/United Kingdom/GB/;
-s/Austria/AT/;s/Belgium/BE/;s/Bulgaria/BG/;s/Brazil/BR/;s/Switzerland/CH/;s/Czech Republic/CZ/;s/Denmark/DK/;s/Spain/ES/;s/France/FR/;
-s/Hong Kong/HK/;s/Hungary/HU/;s/Ireland/IE/;s/Israel/IL/;s/India/IN/;s/Italy/IT/;s/Japan/JP/;s/Mexico/MX/;s/Netherlands/NL/;s/Norway/NO/;s/New Zealand/NZ/;
-s/Poland/PL/;s/Romania/RO/;s/Serbia/RS/;s/Sweden/SE/;s/Singapore/SG/;s/South Africa/ZA/;s/_/ /g;'
-}
-
-getCountryNames(){
-	if [ "$1" = "NordVPN" ]; then
-		echo "$2" | jq -r -e '.[] | .name // empty'
-	elif [ "$1" = "PIA" ] || [ "$1" = "WeVPN" ]; then
-		echo "$2" | sedCountryCodesDestructive | awk '{$1=$1;print}' | awk '{for(i=1;i<=NF;i++){ $i=toupper(substr($i,1,1)) substr($i,2) }}1' | sort -u
-	fi
-}
-
-getCountryID(){
-	echo "$1" | jq -r -e '.[] | select(.name=="'"$2"'") | .id // empty'
-}
-
-getCityCount(){
-	if [ "$1" = "NordVPN" ]; then
-		echo "$2" | jq -r -e '.[] | select(.name=="'"$3"'") | .cities | length // empty'
-	elif [ "$1" = "PIA" ] || [ "$1" = "WeVPN" ]; then
-		echo "$2" | sedCountryCodesDestructive | sort | grep -c "$3"
-	fi
-}
-
-getCityNames(){
-	if [ "$1" = "NordVPN" ]; then
-		echo "$2" | jq -r -e '.[] | select(.name=="'"$3"'") | .cities[] | .name // empty'
-	elif [ "$1" = "PIA" ] || [ "$1" = "WeVPN" ]; then
-		echo "$2" | sedCountryCodes | grep "$3" | sed "s/$3//" | awk '{$1=$1;print}' | awk '{for(i=1;i<=NF;i++){ $i=toupper(substr($i,1,1)) substr($i,2) }}1' | sort
-	fi
-}
-
-getCityID(){
-	echo "$1" | jq -r -e '.[] | select(.name=="'"$2"'") | .cities[] | select(.name=="'"$3"'") | .id // empty'
-}
-
 getIP(){
 	echo "$1" | grep "^remote " | cut -f2 -d' '
-}
-
-getHostname(){
-	echo "$1" | jq -r -e '.hostname // empty'
-}
-
-getOVPNcontents(){
-	/usr/sbin/curl -fsL --retry 3 "https://downloads.nordcdn.com/configs/files/ovpn_$2/servers/$1"
 }
 
 getPort(){
@@ -701,68 +637,8 @@ getClientCA(){
 	echo "$1" | awk '/<ca>/{flag=1;next}/<\/ca>/{flag=0}flag' | sed '/^#/ d'
 }
 
-getClientCert(){
-	echo "$1" | awk '/<cert>/{flag=1;next}/<\/cert>/{flag=0}flag' | sed '/^#/ d'
-}
-
-getStaticKey(){
-	if [ "$2" = "NordVPN" ]; then
-		echo "$1" | awk '/<tls-auth>/{flag=1;next}/<\/tls-auth>/{flag=0}flag' | sed '/^#/ d'
-	elif [ "$2" = "WeVPN" ]; then
-		echo "$1" | awk '/<tls-crypt>/{flag=1;next}/<\/tls-crypt>/{flag=0}flag' | sed '/^#/ d'
-	fi
-}
-
-getKey(){
-	echo "$1" | awk '/<key>/{flag=1;next}/<\/key>/{flag=0}flag' | sed '/^#/ d'
-}
-
-getCRL(){
-	echo "$1" | awk '/<crl-verify>/{flag=1;next}/<\/crl-verify>/{flag=0}flag' | sed '/^#/ d'
-}
-
 getConnectState(){
 	nvram get vpn_client"$1"_state
-}
-
-getOVPNArchives(){
-	Print_Output true "Refreshing OpenVPN file archives..."
-	
-	### PIA ###
-	# Standard UDP
-	Download_File https://www.privateinternetaccess.com/openvpn/openvpn.zip /tmp/pia_udp_standard.zip
-	# Standard TCP
-	Download_File https://www.privateinternetaccess.com/openvpn/openvpn-tcp.zip /tmp/pia_tcp_standard.zip
-	# Strong UDP
-	Download_File https://www.privateinternetaccess.com/openvpn/openvpn-strong.zip /tmp/pia_udp_strong.zip
-	# Strong TCP
-	Download_File https://www.privateinternetaccess.com/openvpn/openvpn-strong-tcp.zip /tmp/pia_tcp_strong.zip
-	###########
-	
-	piachanged="$(CompareArchiveContents "/tmp/pia_udp_standard.zip /tmp/pia_tcp_standard.zip /tmp/pia_udp_strong.zip /tmp/pia_tcp_strong.zip")"
-	
-	if [ "$piachanged" = "true" ]; then
-		/opt/bin/7za -ba l "$OVPN_ARCHIVE_DIR/pia_udp_standard.zip" -- *.ovpn | awk '{ for (i = 6; i <= NF; i++) { printf "%s ",$i } printf "\n"}' | sed 's/\.ovpn//' | sort | awk '{$1=$1;print}' > "$SCRIPT_DIR/pia_countrydata"
-		Print_Output true "Changes detected in PIA OpenVPN file archives, local copies updated" "$PASS"
-	else
-		Print_Output true "No changes in PIA OpenVPN file archives" "$WARN"
-	fi
-	
-	### WeVPN ###
-	# Standard UDP
-	Download_File "$SCRIPT_REPO/wevpn_udp_standard.zip" /tmp/wevpn_udp_standard.zip
-	# Standard TCP
-	Download_File "$SCRIPT_REPO/wevpn_tcp_standard.zip" /tmp/wevpn_tcp_standard.zip
-	###########
-	
-	wevpnchanged="$(CompareArchiveContents "/tmp/wevpn_udp_standard.zip /tmp/wevpn_tcp_standard.zip")"
-	
-	if [ "$wevpnchanged" = "true" ]; then
-		/opt/bin/7za -ba l "$OVPN_ARCHIVE_DIR/wevpn_tcp_standard.zip" -- *.ovpn | awk '{ for (i = 6; i <= NF; i++) { printf "%s ",$i } printf "\n"}' | sed 's/\.ovpn//;s/-UDP//;s/-TCP//;s/_/ /;' | sort | awk '{$1=$1;print}' > "$SCRIPT_DIR/wevpn_countrydata"
-		Print_Output true "Changes detected in WeVPN OpenVPN file archives, local copies updated" "$PASS"
-	else
-		Print_Output true "No changes in WeVPN OpenVPN file archives" "$WARN"
-	fi
 }
 
 CompareArchiveContents(){
@@ -793,14 +669,14 @@ ListVPNClients(){
 	showunmanaged="$2"
 	
 	if [ "$showload" = "true" ]; then
-		printf "Checking server loads using NordVPN API...\\n\\n"
+		printf "Checking server loads...\\n\\n"
 	fi
 	
 	printf "VPN client list:\\n\\n"
 	for i in 1 2 3 4 5; do
 		VPN_CLIENTDESC="$(nvram get vpn_client"$i"_desc)"
 		if [ "$showload" = "true" ]; then
-			if ! echo "$VPN_CLIENTDESC" | grep -iq "nordvpn"; then
+			if [ -z "$VPN_CLIENTDESC" ]; then
 				continue
 			fi
 		fi
@@ -837,7 +713,12 @@ ListVPNClients(){
 		[ -z "$CITYNAME" ] && CITYNAME="None"
 		
 		if [ "$showload" = "true" ]; then
-			SERVERLOAD="$(getServerLoad "$VPN_CLIENTDESC")"
+			_ll_prov="$(grep "vpn${i}_provider" "$SCRIPT_CONF" | cut -f2 -d"=" | tr 'A-Z' 'a-z')"
+			if Load_Provider "$_ll_prov" 2>/dev/null; then
+				SERVERLOAD="$("provider_${_ll_prov}_get_server_load" "$VPN_CLIENTDESC")"
+			else
+				SERVERLOAD="Unknown"
+			fi
 		fi
 		
 		if [ "$(grep "vpn${i}_managed" "$SCRIPT_CONF" | cut -f2 -d"=")" = "true" ]; then
@@ -861,71 +742,28 @@ UpdateVPNConfig(){
 	fi
 	VPN_NO="$1"
 	VPN_PROVIDER="$(grep "vpn${VPN_NO}_provider" "$SCRIPT_CONF" | cut -f2 -d"=")"
+	VPN_PROVIDER_LC="$(printf '%s' "$VPN_PROVIDER" | tr 'A-Z' 'a-z')"
 	VPN_PROT_SHORT="$(grep "vpn${VPN_NO}_protocol" "$SCRIPT_CONF" | cut -f2 -d"=")"
-	VPN_PROT="openvpn_$(echo "$VPN_PROT_SHORT" | tr "A-Z" "a-z")"
 	VPN_TYPE_SHORT="$(grep "vpn${VPN_NO}_type" "$SCRIPT_CONF" | cut -f2 -d"=")"
-	VPN_TYPE=""
-	if [ "$VPN_TYPE_SHORT" = "Double" ]; then
-		VPN_TYPE="legacy_$(echo "$VPN_TYPE_SHORT" | tr "A-Z" "a-z")""_vpn"
-	else
-		VPN_TYPE="legacy_$(echo "$VPN_TYPE_SHORT" | tr "A-Z" "a-z")"
-	fi
 	VPN_COUNTRYID="$(grep "vpn${VPN_NO}_countryid" "$SCRIPT_CONF" | cut -f2 -d"=")"
 	VPN_COUNTRYNAME="$(grep "vpn${VPN_NO}_countryname" "$SCRIPT_CONF" | cut -f2 -d"=")"
 	VPN_CITYID="$(grep "vpn${VPN_NO}_cityid" "$SCRIPT_CONF" | cut -f2 -d"=")"
 	VPN_CITYNAME="$(grep "vpn${VPN_NO}_cityname" "$SCRIPT_CONF" | cut -f2 -d"=")"
-	vJSON=""
-	OVPNFILE=""
 	OVPN_ADDR=""
-	
-	if [ "$VPN_PROVIDER" = "NordVPN" ]; then
-		Print_Output true "Retrieving recommended VPN server using NordVPN API with below parameters"
-		if [ "$VPN_COUNTRYID" -eq 0 ]; then
-			Print_Output true "Protocol: $VPN_PROT_SHORT - Type: $VPN_TYPE_SHORT" "$PASS"
-			vJSON="$(getRecommendedServers "$VPN_TYPE" "$VPN_PROT" "$VPN_COUNTRYID")"
-		else
-			if [ "$VPN_CITYID" -eq 0 ]; then
-				Print_Output true "Protocol: $VPN_PROT_SHORT - Type: $VPN_TYPE_SHORT - Country: $VPN_COUNTRYNAME" "$PASS"
-				vJSON="$(getRecommendedServers "$VPN_TYPE" "$VPN_PROT" "$VPN_COUNTRYID")"
-			else
-				Print_Output true "Protocol: $VPN_PROT_SHORT - Type: $VPN_TYPE_SHORT - Country: $VPN_COUNTRYNAME - City: $VPN_CITYNAME" "$PASS"
-				vJSON="$(getServersforCity "$VPN_TYPE" "$VPN_PROT" "$VPN_COUNTRYID" "$VPN_CITYID")"
-				if [ -z "$vJSON" ]; then
-					Print_Output true "No VPN servers found for $VPN_CITYNAME, removing filter for city" "$WARN"
-					vJSON="$(getRecommendedServers "$VPN_TYPE" "$VPN_PROT" "$VPN_COUNTRYID")"
-					if [ -z "$vJSON" ]; then
-						Print_Output true "No VPN servers found for $VPN_COUNTRYNAME, removing filter for country" "$WARN"
-						vJSON="$(getRecommendedServers "$VPN_TYPE" "$VPN_PROT" 0)"
-					fi
-				fi
-			fi
-		fi
-		
-		[ -z "$vJSON" ] && Print_Output true "Error contacting NordVPN API" "$ERR" && return 1
-		OVPN_HOSTNAME="$(getHostname "$vJSON")"
-		[ -z "$OVPN_HOSTNAME" ] && Print_Output true "Could not determine hostname for VPN server" "$ERR" && return 1
-		OVPNFILE="$OVPN_HOSTNAME.$(echo "$VPN_PROT" | cut -f2 -d"_").ovpn"
-		OVPN_DETAIL="$(getOVPNcontents "$OVPNFILE" "$(echo "$VPN_PROT" | cut -f2 -d"_")")"
-	elif [ "$VPN_PROVIDER" = "PIA" ]; then
-		OVPNARCHIVE="$OVPN_ARCHIVE_DIR/pia_$(echo "$VPN_PROT" | cut -f2 -d"_")_$(echo "$VPN_TYPE" | cut -f2 -d"_").zip"
-		OVPN_FILENAME="$(echo "$VPN_COUNTRYNAME" | sedReverseCountryCodesPIA)"
-		if [ -n "$VPN_CITYNAME" ]; then
-			OVPN_FILENAME="${OVPN_FILENAME}_${VPN_CITYNAME}"
-		fi
-		OVPN_FILENAME="$(echo "$OVPN_FILENAME" | tr "A-Z" "a-z" | sed 's/ /_/g;')"
-		/opt/bin/7za e -bsp0 -bso0 "$OVPNARCHIVE" -o/tmp "$OVPN_FILENAME.ovpn"
-		OVPN_DETAIL="$(cat "/tmp/$OVPN_FILENAME.ovpn")"
-		rm -f "/tmp/$OVPN_FILENAME.ovpn"
-	elif [ "$VPN_PROVIDER" = "WeVPN" ]; then
-		OVPNARCHIVE="$OVPN_ARCHIVE_DIR/wevpn_$(echo "$VPN_PROT" | cut -f2 -d"_")_$(echo "$VPN_TYPE" | cut -f2 -d"_").zip"
-		OVPN_FILENAME="$(echo "$VPN_COUNTRYNAME" | sedReverseCountryCodesWeVPN)"'_'"$(echo "$VPN_CITYNAME" | tr "A-Z" "a-z")-$VPN_PROT_SHORT"
-		/opt/bin/7za e -bsp0 -bso0 "$OVPNARCHIVE" -o/tmp "$OVPN_FILENAME.ovpn"
-		OVPN_DETAIL="$(cat "/tmp/$OVPN_FILENAME.ovpn")"
-		rm -f "/tmp/$OVPN_FILENAME.ovpn"
-	fi
-	
+
+	Load_Provider "$VPN_PROVIDER_LC" || return 1
+
+	Print_Output true "Retrieving VPN server for $VPN_PROVIDER (Protocol: $VPN_PROT_SHORT, Type: $VPN_TYPE_SHORT)"
+
+	OVPN_HOSTNAME="$("provider_${VPN_PROVIDER_LC}_get_server" \
+		"$VPN_COUNTRYID" "$VPN_COUNTRYNAME" \
+		"$VPN_CITYID" "$VPN_CITYNAME" \
+		"$VPN_PROT_SHORT" "$VPN_TYPE_SHORT")"
+	[ -z "$OVPN_HOSTNAME" ] && Print_Output true "Could not determine server identifier for VPN client $VPN_NO" "$ERR" && return 1
+
+	OVPN_DETAIL="$("provider_${VPN_PROVIDER_LC}_get_ovpn" "$OVPN_HOSTNAME" "$VPN_PROT_SHORT" "$VPN_TYPE_SHORT")"
 	[ -z "$OVPN_DETAIL" ] && Print_Output true "Error retrieving VPN server ovpn file" "$ERR" && return 1
-	
+
 	OVPN_ADDR="$(getIP "$OVPN_DETAIL")"
 	[ -z "$OVPN_ADDR" ] && Print_Output true "Could not determine address for VPN server" "$ERR" && return 1
 	OVPN_PORT="$(getPort "$OVPN_DETAIL")"
@@ -936,31 +774,9 @@ UpdateVPNConfig(){
 	[ -z "$OVPN_AUTHDIGEST" ] && Print_Output true "Error determining auth digest for VPN server" "$ERR" && return 1
 	CLIENT_CA="$(getClientCA "$OVPN_DETAIL")"
 	[ -z "$CLIENT_CA" ] && Print_Output true "Error determing VPN server Certificate Authority certificate" "$ERR" && return 1
-	
-	STATIC_KEY=""
-	if [ "$VPN_PROVIDER" != "PIA" ]; then
-		STATIC_KEY="$(getStaticKey "$OVPN_DETAIL" "$VPN_PROVIDER")"
-		[ -z "$STATIC_KEY" ] && Print_Output true "Error determing VPN static key" "$ERR" && return 1
-	fi
-	
-	CLIENT_KEY=""
-	if [ "$VPN_PROVIDER" = "WeVPN" ]; then
-		CLIENT_KEY="$(getKey "$OVPN_DETAIL")"
-		[ -z "$CLIENT_KEY" ] && Print_Output true "Error determing VPN client key" "$ERR" && return 1
-	fi
-	
-	CLIENT_CRT=""
-	if [ "$VPN_PROVIDER" = "WeVPN" ]; then
-		CLIENT_CRT="$(getClientCert "$OVPN_DETAIL")"
-		[ -z "$CLIENT_CRT" ] && Print_Output true "Error determing VPN client cert" "$ERR" && return 1
-	fi
-	
-	CLIENT_CRL=""
-	if [ "$VPN_PROVIDER" = "PIA" ]; then
-		CLIENT_CRL="$(getCRL "$OVPN_DETAIL")"
-		[ -z "$CLIENT_CRL" ] && Print_Output true "Error determing VPN client CRL" "$ERR" && return 1
-	fi
-	
+
+	OVPN_HOSTNAME_SHORT="$("provider_${VPN_PROVIDER_LC}_get_short_name" "$OVPN_HOSTNAME" "$OVPN_ADDR")"
+
 	EXISTING_ADDR="$(nvram get vpn_client"$VPN_NO"_addr)"
 	EXISTING_PORT="$(nvram get vpn_client"$VPN_NO"_port)"
 	EXISTING_PROTO="$(nvram get vpn_client"$VPN_NO"_proto)"
@@ -969,26 +785,13 @@ UpdateVPNConfig(){
 	elif [ "$EXISTING_PROTO" = "udp" ]; then
 		EXISTING_PROTO="UDP"
 	fi
-	
-	OVPN_HOSTNAME_SHORT=""
-	if [ "$VPN_PROVIDER" = "NordVPN" ]; then
-		OVPN_HOSTNAME_SHORT="$(echo "$OVPN_HOSTNAME" | cut -f1 -d'.' | tr "a-z" "A-Z")"
-	elif [ "$VPN_PROVIDER" = "PIA" ]; then
-		if echo "$OVPN_ADDR" | grep -q "-" ; then
-			OVPN_HOSTNAME_SHORT="$(echo "$OVPN_ADDR" | cut -f1 -d'.' | awk '{print toupper(substr($0,0,2))tolower(substr($0,3))}')"
-		else
-			OVPN_HOSTNAME_SHORT="$(echo "$OVPN_ADDR" | cut -f1 -d'.' | awk '{print toupper(substr($0,0,1))tolower(substr($0,2))}')"
-		fi
-	elif [ "$VPN_PROVIDER" = "WeVPN" ]; then
-		OVPN_HOSTNAME_SHORT="$(echo "$OVPN_ADDR" | cut -f1 -d'.' | awk '{print toupper(substr($0,0,1))tolower(substr($0,2))}')"
-	fi
-	
+
 	if [ "$OVPN_ADDR" = "$EXISTING_ADDR" ] && [ "$OVPN_PORT" = "$EXISTING_PORT" ] && [ "$VPN_PROT_SHORT" = "$EXISTING_PROTO" ]; then
 		Print_Output true "VPN client $VPN_NO server - unchanged" "$WARN"
 	else
 		Print_Output true "Updating VPN client $VPN_NO to new $VPN_PROVIDER server"
 	fi
-	
+
 	if [ -z "$(nvram get vpn_client"$VPN_NO"_addr)" ]; then
 		nvram set vpn_client"$VPN_NO"_adns=3
 		nvram set vpn_client"$VPN_NO"_enforce=1
@@ -1001,7 +804,7 @@ UpdateVPNConfig(){
 			nvram set vpn_clientx_eas="$(nvram get vpn_clientx_eas),$VPN_NO"
 		fi
 	fi
-	
+
 	nvram set vpn_client"$VPN_NO"_addr="$OVPN_ADDR"
 	nvram set vpn_client"$VPN_NO"_port="$OVPN_PORT"
 	if [ "$VPN_PROT_SHORT" = "TCP" ]; then
@@ -1010,7 +813,7 @@ UpdateVPNConfig(){
 		nvram set vpn_client"$VPN_NO"_proto="udp"
 	fi
 	nvram set vpn_client"$VPN_NO"_desc="$VPN_PROVIDER $OVPN_HOSTNAME_SHORT $VPN_TYPE_SHORT $VPN_PROT_SHORT"
-	
+
 	nvram set vpn_client"$VPN_NO"_cipher="$OVPN_CIPHER"
 	nvram set vpn_client"$VPN_NO"_crypt="tls"
 	nvram set vpn_client"$VPN_NO"_digest="$OVPN_AUTHDIGEST"
@@ -1023,34 +826,28 @@ UpdateVPNConfig(){
 	nvram set vpn_client"$VPN_NO"_tlsremote=0
 	nvram set vpn_client"$VPN_NO"_userauth=1
 	nvram set vpn_client"$VPN_NO"_useronly=0
-	
-	if [ "$VPN_PROVIDER" = "NordVPN" ] || [ "$VPN_PROVIDER" = "WeVPN" ]; then
-		nvram set vpn_client"$VPN_NO"_comp="-1"
-	elif [ "$VPN_PROVIDER" = "PIA" ]; then
-		nvram set vpn_client"$VPN_NO"_comp="no"
-	fi
-	
-	if [ "$VPN_PROVIDER" = "NordVPN" ] || [ "$VPN_PROVIDER" = "PIA" ]; then
-		nvram set vpn_client"$VPN_NO"_hmac=1
-	elif [ "$VPN_PROVIDER" = "WeVPN" ]; then
-		nvram set vpn_client"$VPN_NO"_hmac=3
-	fi
-	
+
+	VPN_COMP="$("provider_${VPN_PROVIDER_LC}_get_comp")"
+	nvram set vpn_client"$VPN_NO"_comp="$VPN_COMP"
+
+	VPN_HMAC="$("provider_${VPN_PROVIDER_LC}_get_hmac")"
+	nvram set vpn_client"$VPN_NO"_hmac="$VPN_HMAC"
+
 	if [ "$(Firmware_Number_Check "$(nvram get buildno)")" -lt "$(Firmware_Number_Check 384.19)" ]; then
 		nvram set vpn_client"$VPN_NO"_connretry="-1"
 	else
 		nvram set vpn_client"$VPN_NO"_connretry=0
 	fi
-	
+
 	if [ "$(grep "vpn${VPN_NO}_customsettings" "$SCRIPT_CONF" | cut -f2 -d"=")" = "true" ]; then
 		SetVPNCustomSettings "$VPN_NO"
 	fi
-	
+
 	if [ "$ISUNATTENDED" = "true" ]; then
 		if [ -z "$(nvram get vpn_client"$VPN_NO"_username)" ]; then
 			Print_Output true "No username set for VPN client $VPN_NO" "$WARN"
 		fi
-		
+
 		if [ -z "$(nvram get vpn_client"$VPN_NO"_password)" ]; then
 			Print_Output true "No password set for VPN client $VPN_NO" "$WARN"
 		fi
@@ -1081,7 +878,7 @@ UpdateVPNConfig(){
 				esac
 			done
 		fi
-		
+
 		if [ -z "$(nvram get vpn_client"$VPN_NO"_username)" ]; then
 			printf "\\n${BOLD}No username set for VPN client %s${CLEARFORMAT}\\n" "$VPN_NO"
 			printf "Please enter username:  "
@@ -1089,7 +886,7 @@ UpdateVPNConfig(){
 			nvram set vpn_client"$VPN_NO"_username="$vpnusn"
 			printf "\\n"
 		fi
-		
+
 		if [ -z "$(nvram get vpn_client"$VPN_NO"_password)" ]; then
 			printf "\\n${BOLD}No password set for VPN client %s${CLEARFORMAT}\\n" "$VPN_NO"
 			printf "Please enter password:  "
@@ -1098,34 +895,16 @@ UpdateVPNConfig(){
 			printf "\\n"
 		fi
 	fi
-	
+
 	nvram commit
-	
-	if [ "$VPN_PROVIDER" = "NordVPN" ]; then
-		echo "$CLIENT_CA" > /jffs/openvpn/vpn_crt_client"$VPN_NO"_ca
-		echo "$STATIC_KEY" > /jffs/openvpn/vpn_crt_client"$VPN_NO"_static
-		rm -f /jffs/openvpn/vpn_crt_client"$VPN_NO"_crl
-		rm -f /jffs/openvpn/vpn_crt_client"$VPN_NO"_key
-		rm -f /jffs/openvpn/vpn_crt_client"$VPN_NO"_crt
-	elif [ "$VPN_PROVIDER" = "PIA" ]; then
-		echo "$CLIENT_CA" > /jffs/openvpn/vpn_crt_client"$VPN_NO"_ca
-		echo "$CLIENT_CRL" > /jffs/openvpn/vpn_crt_client"$VPN_NO"_crl
-		rm -f /jffs/openvpn/vpn_crt_client"$VPN_NO"_static
-		rm -f /jffs/openvpn/vpn_crt_client"$VPN_NO"_key
-		rm -f /jffs/openvpn/vpn_crt_client"$VPN_NO"_crt
-	elif [ "$VPN_PROVIDER" = "WeVPN" ]; then
-		echo "$CLIENT_CA" > /jffs/openvpn/vpn_crt_client"$VPN_NO"_ca
-		echo "$CLIENT_CRT" > /jffs/openvpn/vpn_crt_client"$VPN_NO"_crt
-		echo "$STATIC_KEY" > /jffs/openvpn/vpn_crt_client"$VPN_NO"_static
-		echo "$CLIENT_KEY" > /jffs/openvpn/vpn_crt_client"$VPN_NO"_key
-		rm -f /jffs/openvpn/vpn_crt_client"$VPN_NO"_crl
-	fi
-	
+
+	"provider_${VPN_PROVIDER_LC}_write_certs" "$VPN_NO" "$OVPN_DETAIL" || return 1
+
 	retry="false"
-	
+
 	if nvram get vpn_clientx_eas | grep -q "$VPN_NO"; then
 		RestartVPNClient "$VPN_NO"
-		
+
 		Print_Output true "Testing that VPN client $VPN_NO is up with a 10s ping test to 1.1.1.1 ($OVPN_HOSTNAME_SHORT $VPN_TYPE_SHORT $VPN_PROT_SHORT)"
 		tunnelup="false"
 		for i in 1 2 3; do
@@ -1136,7 +915,7 @@ UpdateVPNConfig(){
 				RestartVPNClient "$VPN_NO"
 			fi
 		done
-		
+
 		if [ "$tunnelup" = "false" ]; then
 			Print_Output true "VPN client $VPN_NO did not come up after 3 attempts, please investigate! ($OVPN_HOSTNAME_SHORT $VPN_TYPE_SHORT $VPN_PROT_SHORT)" "$CRIT"
 			if [ "$ISUNATTENDED" != "true" ]; then
@@ -1313,7 +1092,6 @@ SetVPNParameters(){
 	vpnprovider=""
 	vpnprot=""
 	vpntype=""
-	countrydata=""
 	choosecountry=""
 	choosecity=""
 	countryname=""
@@ -1382,73 +1160,44 @@ SetVPNParameters(){
 	fi
 	
 	if [ "$exitmenu" != "exit" ]; then
-		if [ "$vpnprovider" = "NordVPN" ]; then
+		vpnprovider_lc="$(printf '%s' "$vpnprovider" | tr 'A-Z' 'a-z')"
+		Load_Provider "$vpnprovider_lc" || { exitmenu="exit"; }
+	fi
+
+	if [ "$exitmenu" != "exit" ]; then
+		typelist="$("provider_${vpnprovider_lc}_get_types")"
+		COUNTYPES="$(printf '%s\n' "$typelist" | wc -l)"
+		if [ "$COUNTYPES" -eq 1 ]; then
+			vpntype="$(printf '%s\n' "$typelist" | sed -n '1p')"
+		else
 			while true; do
 				printf "\\n${BOLD}Please select a VPN Type:${CLEARFORMAT}\\n"
-				printf "    1. Standard\\n"
-				printf "    2. Double\\n"
-				printf "    3. P2P\\n\\n"
-				printf "Choose an option:  "
+				COUNTER=1
+				IFS="$(printf '\n')"
+				for VTYPE in $typelist; do
+					printf "    %s. %s\\n" "$COUNTER" "$VTYPE"
+					COUNTER=$((COUNTER+1))
+				done
+				unset IFS
+				printf "\\nChoose an option:  "
 				read -r typemenu
-				
-				case "$typemenu" in
-					1)
-						vpntype="legacy_standard"
-						printf "\\n"
-						break
-					;;
-					2)
-						vpntype="legacy_double_vpn"
-						printf "\\n"
-						break
-					;;
-					3)
-						vpntype="legacy_p2p"
-						printf "\\n"
-						break
-					;;
-					e)
-						exitmenu="exit"
-						break
-					;;
-					*)
-						printf "\\n\\e[31mPlease enter a valid choice (1-3)${CLEARFORMAT}\\n"
-					;;
-				esac
+
+				if [ "$typemenu" = "e" ]; then
+					exitmenu="exit"
+					break
+				elif ! Validate_Number "$typemenu"; then
+					printf "\\n\\e[31mPlease enter a valid number (1-%s)${CLEARFORMAT}\\n" "$COUNTYPES"
+				elif [ "$typemenu" -lt 1 ] || [ "$typemenu" -gt "$COUNTYPES" ]; then
+					printf "\\n\\e[31mPlease enter a number between 1 and %s${CLEARFORMAT}\\n" "$COUNTYPES"
+				else
+					vpntype="$(printf '%s\n' "$typelist" | sed -n "${typemenu}p")"
+					printf "\\n"
+					break
+				fi
 			done
-		elif [ "$vpnprovider" = "PIA" ]; then
-			while true; do
-				printf "\\n${BOLD}Please select a VPN Type:${CLEARFORMAT}\\n"
-				printf "    1. Standard\\n"
-				printf "    2. Strong\\n\\n"
-				printf "Choose an option:  "
-				read -r typemenu
-				
-				case "$typemenu" in
-					1)
-						vpntype="standard"
-						printf "\\n"
-						break
-					;;
-					2)
-						vpntype="strong"
-						printf "\\n"
-						break
-					;;
-					e)
-						exitmenu="exit"
-						break
-					;;
-					*)
-						printf "\\n\\e[31mPlease enter a valid choice (1-3)${CLEARFORMAT}\\n"
-					;;
-				esac
-			done
-		elif [ "$vpnprovider" = "WeVPN" ]; then
-			vpntype="standard"
 		fi
 	fi
-	
+
 	if [ "$exitmenu" != "exit" ]; then
 		while true; do
 			printf "\\n${BOLD}Please select a VPN protocol:${CLEARFORMAT}\\n"
@@ -1456,15 +1205,15 @@ SetVPNParameters(){
 			printf "    2. TCP\\n\\n"
 			printf "Choose an option:  "
 			read -r protmenu
-			
+
 			case "$protmenu" in
 				1)
-					vpnprot="openvpn_udp"
+					vpnprot="UDP"
 					printf "\\n"
 					break
 				;;
 				2)
-					vpnprot="openvpn_tcp"
+					vpnprot="TCP"
 					printf "\\n"
 					break
 				;;
@@ -1478,178 +1227,134 @@ SetVPNParameters(){
 			esac
 		done
 	fi
-	
-		if [ "$exitmenu" != "exit" ]; then
-			if [ "$vpnprovider" = "NordVPN" ]; then
-				while true; do
-					printf "\\n${BOLD}Would you like to select a country (y/n)?${CLEARFORMAT}  "
-					read -r country_select
-					
-					if [ "$country_select" = "e" ]; then
-						exitmenu="exit"
-						break
-					elif [ "$country_select" = "n" ] || [ "$country_select" = "N" ]; then
-						choosecountry="false"
-						printf "\\n"
-						break
-					elif [ "$country_select" = "y" ] || [ "$country_select" = "Y" ]; then
-						choosecountry="true"
-						break
-					else
-						printf "\\n\\e[31mPlease enter y or n${CLEARFORMAT}\\n"
-					fi
-				done
-			elif [ "$vpnprovider" = "PIA" ] || [ "$vpnprovider" = "WeVPN" ]; then
-				choosecountry="true"
-			fi
-		fi
-		
-		if [ "$choosecountry" = "true" ]; then
-			LISTCOUNTRIES=""
-			if [ "$vpnprovider" = "NordVPN" ]; then
-				countrydata="$(cat "$SCRIPT_DIR/nordvpn_countrydata")"
-				[ -z "$countrydata" ] && Print_Output true "Error, country data from NordVPN is missing" "$ERR" && return 1
-				LISTCOUNTRIES="$(getCountryNames NordVPN "$countrydata")"
-			elif [ "$vpnprovider" = "PIA" ]; then
-				countrydata="$(cat "$SCRIPT_DIR/pia_countrydata")"
-				[ -z "$countrydata" ] && Print_Output true "Error, country data from PIA is missing" "$ERR" && return 1
-				LISTCOUNTRIES="$(getCountryNames PIA "$countrydata")"
-			elif [ "$vpnprovider" = "WeVPN" ]; then
-				countrydata="$(cat "$SCRIPT_DIR/wevpn_countrydata")"
-				[ -z "$countrydata" ] && Print_Output true "Error, country data from WeVPN is missing" "$ERR" && return 1
-				LISTCOUNTRIES="$(getCountryNames WeVPN "$countrydata")"
-			fi
-			COUNTCOUNTRIES="$(echo "$LISTCOUNTRIES" | wc -l)"
+
+	if [ "$exitmenu" != "exit" ]; then
+		if "provider_${vpnprovider_lc}_country_required"; then
+			choosecountry="true"
+		else
 			while true; do
-				printf "\\n${BOLD}Please select a country:${CLEARFORMAT}\\n"
-				COUNTER=1
-				IFS=$'\n'
-				for COUNTRY in $LISTCOUNTRIES; do
-					printf "    %s. %s\\n" "$COUNTER" "$COUNTRY" >> /tmp/vpnmgr_countrylist
-					COUNTER=$((COUNTER+1))
-				done
-				column /tmp/vpnmgr_countrylist
-				rm -f /tmp/vpnmgr_countrylist
-				unset IFS
-				
-				printf "\\nChoose an option:  "
-				read -r country_choice
-				
-				if [ "$country_choice" = "e" ]; then
+				printf "\\n${BOLD}Would you like to select a country (y/n)?${CLEARFORMAT}  "
+				read -r country_select
+
+				if [ "$country_select" = "e" ]; then
 					exitmenu="exit"
 					break
-				elif ! Validate_Number "$country_choice"; then
-					printf "\\n\\e[31mPlease enter a valid number (1-%s)${CLEARFORMAT}\\n" "$COUNTCOUNTRIES"
+				elif [ "$country_select" = "n" ] || [ "$country_select" = "N" ]; then
+					choosecountry="false"
+					printf "\\n"
+					break
+				elif [ "$country_select" = "y" ] || [ "$country_select" = "Y" ]; then
+					choosecountry="true"
+					break
 				else
-					if [ "$country_choice" -lt 1 ] || [ "$country_choice" -gt "$COUNTCOUNTRIES" ]; then
-						printf "\\n\\e[31mPlease enter a number between 1 and %s${CLEARFORMAT}\\n" "$COUNTCOUNTRIES"
-					else
-						countryname="$(echo "$LISTCOUNTRIES" | sed -n "$country_choice"p)"
-						if [ "$vpnprovider" = "NordVPN" ]; then
-							countryid="$(getCountryID "$countrydata" "$countryname")"
+					printf "\\n\\e[31mPlease enter y or n${CLEARFORMAT}\\n"
+				fi
+			done
+		fi
+	fi
+
+	if [ "$choosecountry" = "true" ]; then
+		LISTCOUNTRIES="$("provider_${vpnprovider_lc}_get_country_names")"
+		[ -z "$LISTCOUNTRIES" ] && Print_Output true "Error, country data for $vpnprovider is missing" "$ERR" && return 1
+		COUNTCOUNTRIES="$(printf '%s\n' "$LISTCOUNTRIES" | wc -l)"
+		while true; do
+			printf "\\n${BOLD}Please select a country:${CLEARFORMAT}\\n"
+			COUNTER=1
+			IFS="$(printf '\n')"
+			for COUNTRY in $LISTCOUNTRIES; do
+				printf "    %s. %s\\n" "$COUNTER" "$COUNTRY" >> /tmp/vpnmgr_countrylist
+				COUNTER=$((COUNTER+1))
+			done
+			column /tmp/vpnmgr_countrylist
+			rm -f /tmp/vpnmgr_countrylist
+			unset IFS
+
+			printf "\\nChoose an option:  "
+			read -r country_choice
+
+			if [ "$country_choice" = "e" ]; then
+				exitmenu="exit"
+				break
+			elif ! Validate_Number "$country_choice"; then
+				printf "\\n\\e[31mPlease enter a valid number (1-%s)${CLEARFORMAT}\\n" "$COUNTCOUNTRIES"
+			else
+				if [ "$country_choice" -lt 1 ] || [ "$country_choice" -gt "$COUNTCOUNTRIES" ]; then
+					printf "\\n\\e[31mPlease enter a number between 1 and %s${CLEARFORMAT}\\n" "$COUNTCOUNTRIES"
+				else
+					countryname="$(printf '%s\n' "$LISTCOUNTRIES" | sed -n "${country_choice}p")"
+					countryid="$("provider_${vpnprovider_lc}_get_country_id" "$countryname")"
+					printf "\\n"
+					break
+				fi
+			fi
+		done
+
+		if [ "$exitmenu" != "exit" ]; then
+			citycount="$("provider_${vpnprovider_lc}_get_city_count" "$countryname")"
+
+			if [ "$citycount" -eq 1 ]; then
+				cityname="$("provider_${vpnprovider_lc}_get_city_names" "$countryname")"
+				cityid="$("provider_${vpnprovider_lc}_get_city_id" "$countryname" "$cityname")"
+			elif [ "$citycount" -gt 1 ]; then
+				if "provider_${vpnprovider_lc}_city_required"; then
+					choosecity="true"
+				else
+					while true; do
+						printf "\\n${BOLD}Would you like to select a city (y/n)?${CLEARFORMAT}  "
+						read -r city_select
+
+						if [ "$city_select" = "e" ]; then
+							exitmenu="exit"
+							break
+						elif [ "$city_select" = "n" ] || [ "$city_select" = "N" ]; then
+							choosecity="false"
+							printf "\\n"
+							break
+						elif [ "$city_select" = "y" ] || [ "$city_select" = "Y" ]; then
+							choosecity="true"
+							break
+						else
+							printf "\\n\\e[31mPlease enter y or n${CLEARFORMAT}\\n"
 						fi
+					done
+				fi
+			fi
+		fi
+
+		if [ "$choosecity" = "true" ]; then
+			LISTCITIES="$("provider_${vpnprovider_lc}_get_city_names" "$countryname")"
+			COUNTCITIES="$(printf '%s\n' "$LISTCITIES" | wc -l)"
+			while true; do
+				printf "\\n${BOLD}Please select a city:${CLEARFORMAT}\\n"
+				COUNTER=1
+				IFS="$(printf '\n')"
+				for CITY in $LISTCITIES; do
+					printf "    %s. %s\\n" "$COUNTER" "$CITY"
+					COUNTER=$((COUNTER+1))
+				done
+				unset IFS
+
+				printf "\\nChoose an option:  "
+				read -r city_choice
+
+				if [ "$city_choice" = "e" ]; then
+					exitmenu="exit"
+					break
+				elif ! Validate_Number "$city_choice"; then
+					printf "\\n\\e[31mPlease enter a valid number (1-%s)${CLEARFORMAT}\\n" "$COUNTCITIES"
+				else
+					if [ "$city_choice" -lt 1 ] || [ "$city_choice" -gt "$COUNTCITIES" ]; then
+						printf "\\n\\e[31mPlease enter a number between 1 and %s${CLEARFORMAT}\\n" "$COUNTCITIES"
+					else
+						cityname="$(printf '%s\n' "$LISTCITIES" | sed -n "${city_choice}p")"
+						cityid="$("provider_${vpnprovider_lc}_get_city_id" "$countryname" "$cityname")"
 						printf "\\n"
 						break
 					fi
 				fi
 			done
-		
-			if [ "$exitmenu" != "exit" ]; then
-				citycount=0
-				if [ "$vpnprovider" = "NordVPN" ]; then
-					citycount="$(getCityCount NordVPN "$countrydata" "$countryname")"
-				elif [ "$vpnprovider" = "PIA" ]; then
-					countrydata="$(cat "$SCRIPT_DIR/pia_countrydata")"
-					citycount="$(getCityCount PIA "$countrydata" "$countryname")"
-				elif [ "$vpnprovider" = "WeVPN" ]; then
-					countrydata="$(cat "$SCRIPT_DIR/wevpn_countrydata")"
-					citycount="$(getCityCount WeVPN "$countrydata" "$countryname")"
-				fi
-				
-				if [ "$citycount" -eq 1 ]; then
-					if [ "$vpnprovider" = "NordVPN" ]; then
-						cityname="$(getCityNames NordVPN "$countrydata" "$countryname")"
-						cityid="$(getCityID "$countrydata" "$countryname" "$cityname")"
-					elif [ "$vpnprovider" = "PIA" ]; then
-						countrydata="$(cat "$SCRIPT_DIR/pia_countrydata")"
-						cityname="$(getCityNames PIA "$countrydata" "$countryname")"
-					elif [ "$vpnprovider" = "WeVPN" ]; then
-						countrydata="$(cat "$SCRIPT_DIR/wevpn_countrydata")"
-						cityname="$(getCityNames WeVPN "$countrydata" "$countryname")"
-					fi
-				elif [ "$citycount" -gt 1 ]; then
-					if [ "$vpnprovider" = "NordVPN" ]; then
-						while true; do
-							printf "\\n${BOLD}Would you like to select a city (y/n)?${CLEARFORMAT}  "
-							read -r city_select
-							
-							if [ "$city_select" = "e" ]; then
-								exitmenu="exit"
-								break
-							elif [ "$city_select" = "n" ] || [ "$city_select" = "N" ]; then
-								choosecity="false"
-								printf "\\n"
-								break
-							elif [ "$city_select" = "y" ] || [ "$city_select" = "Y" ]; then
-								choosecity="true"
-								break
-							else
-								printf "\\n\\e[31mPlease enter y or n${CLEARFORMAT}\\n"
-							fi
-						done
-					elif [ "$vpnprovider" = "PIA" ] || [ "$vpnprovider" = "WeVPN" ]; then
-						choosecity="true"
-					fi
-				fi
-			fi
-			
-			if [ "$choosecity" = "true" ]; then
-				LISTCITIES=""
-				
-				if [ "$vpnprovider" = "NordVPN" ]; then
-					LISTCITIES="$(getCityNames NordVPN "$countrydata" "$countryname")"
-				elif [ "$vpnprovider" = "PIA" ]; then
-					countrydata="$(cat "$SCRIPT_DIR/pia_countrydata")"
-					LISTCITIES="$(getCityNames PIA "$countrydata" "$countryname")"
-				elif [ "$vpnprovider" = "WeVPN" ]; then
-					countrydata="$(cat "$SCRIPT_DIR/wevpn_countrydata")"
-					LISTCITIES="$(getCityNames WeVPN "$countrydata" "$countryname")"
-				fi
-				
-				COUNTCITIES="$(echo "$LISTCITIES" | wc -l)"
-				while true; do
-					printf "\\n${BOLD}Please select a city:${CLEARFORMAT}\\n"
-					COUNTER=1
-					IFS=$'\n'
-					for CITY in $LISTCITIES; do
-						printf "    %s. %s\\n" "$COUNTER" "$CITY"
-						COUNTER=$((COUNTER+1))
-					done
-					unset IFS
-					
-					printf "\\nChoose an option:  "
-					read -r city_choice
-					
-					if [ "$city_choice" = "e" ]; then
-						exitmenu="exit"
-						break
-					elif ! Validate_Number "$city_choice"; then
-						printf "\\n\\e[31mPlease enter a valid number (1-%s)${CLEARFORMAT}\\n" "$COUNTCITIES"
-					else
-						if [ "$city_choice" -lt 1 ] || [ "$city_choice" -gt "$COUNTCITIES" ]; then
-							printf "\\n\\e[31mPlease enter a number between 1 and %s${CLEARFORMAT}\\n" "$COUNTCITIES"
-						else
-							cityname="$(echo "$LISTCITIES" | sed -n "$city_choice"p)"
-							if [ "$vpnprovider" = "NordVPN" ]; then
-								cityid="$(getCityID "$countrydata" "$countryname" "$cityname")"
-							fi
-							printf "\\n"
-							break
-						fi
-					fi
-				done
-			fi
 		fi
+	fi
 	
 	if [ "$exitmenu" != "exit" ]; then
 		GLOBAL_VPN_NO="$vpnnum"
@@ -2018,7 +1723,7 @@ ScriptHeader(){
 	printf "${BOLD}##                                                   ##${CLEARFORMAT}\\n"
 	printf "${BOLD}##                 %s on %-11s             ##${CLEARFORMAT}\\n" "$SCRIPT_VERSION" "$ROUTER_MODEL"
 	printf "${BOLD}##                                                   ##${CLEARFORMAT}\\n"
-	printf "${BOLD}##         https://github.com/jackyaz/vpnmgr         ##${CLEARFORMAT}\\n"
+	printf "${BOLD}##       https://github.com/h0me5k1n/vpnmgr          ##${CLEARFORMAT}\\n"
 	printf "${BOLD}##                                                   ##${CLEARFORMAT}\\n"
 	printf "${BOLD}#######################################################${CLEARFORMAT}\\n"
 	printf "\\n"
@@ -2137,8 +1842,7 @@ MainMenu(){
 			;;
 			r)
 				printf "\\n"
-				getCountryData
-				getOVPNArchives
+				Refresh_Provider_Cache
 				PressEnter
 				break
 			;;
@@ -2203,17 +1907,9 @@ Menu_UpdateVPN(){
 	printf "${BOLD}#########################################################${CLEARFORMAT}\\n"
 	
 	if SetVPNParameters; then
-		VPN_PROT_SHORT="$(echo "$GLOBAL_VPN_PROT" | cut -f2 -d'_' | tr "a-z" "A-Z")"
-		VPN_TYPE_SHORT="$(echo "$GLOBAL_VPN_TYPE" | cut -f2 -d'_')"
-		if [ "$VPN_TYPE_SHORT" = "p2p" ]; then
-			VPN_TYPE_SHORT="$(echo "$VPN_TYPE_SHORT" | tr "a-z" "A-Z")"
-		else
-			VPN_TYPE_SHORT="$(echo "$VPN_TYPE_SHORT" | awk '{print toupper(substr($0,0,1))tolower(substr($0,2))}')"
-		fi
-		
 		sed -i 's/^vpn'"$GLOBAL_VPN_NO"'_provider.*$/vpn'"$GLOBAL_VPN_NO"'_provider='"$GLOBAL_VPN_PROVIDER"'/' "$SCRIPT_CONF"
-		sed -i 's/^vpn'"$GLOBAL_VPN_NO"'_type.*$/vpn'"$GLOBAL_VPN_NO"'_type='"$VPN_TYPE_SHORT"'/' "$SCRIPT_CONF"
-		sed -i 's/^vpn'"$GLOBAL_VPN_NO"'_protocol.*$/vpn'"$GLOBAL_VPN_NO"'_protocol='"$VPN_PROT_SHORT"'/' "$SCRIPT_CONF"
+		sed -i 's/^vpn'"$GLOBAL_VPN_NO"'_type.*$/vpn'"$GLOBAL_VPN_NO"'_type='"$GLOBAL_VPN_TYPE"'/' "$SCRIPT_CONF"
+		sed -i 's/^vpn'"$GLOBAL_VPN_NO"'_protocol.*$/vpn'"$GLOBAL_VPN_NO"'_protocol='"$GLOBAL_VPN_PROT"'/' "$SCRIPT_CONF"
 		sed -i 's/^vpn'"$GLOBAL_VPN_NO"'_countryname.*$/vpn'"$GLOBAL_VPN_NO"'_countryname='"$GLOBAL_COUNTRY_NAME"'/' "$SCRIPT_CONF"
 		sed -i 's/^vpn'"$GLOBAL_VPN_NO"'_countryid.*$/vpn'"$GLOBAL_VPN_NO"'_countryid='"$GLOBAL_COUNTRY_ID"'/' "$SCRIPT_CONF"
 		sed -i 's/^vpn'"$GLOBAL_VPN_NO"'_cityname.*$/vpn'"$GLOBAL_VPN_NO"'_cityname='"$GLOBAL_CITY_NAME"'/' "$SCRIPT_CONF"
@@ -2300,10 +1996,10 @@ Menu_Install(){
 	
 	Update_File vpnmgr_www.asp
 	Update_File shared-jy.tar.gz
-	
-	getCountryData
-	getOVPNArchives
-	
+
+	Install_Providers
+	Refresh_Provider_Cache
+
 	Shortcut_Script create
 	Clear_Lock
 	
@@ -2426,17 +2122,19 @@ Show_About(){
 	cat <<EOF
 About
   $SCRIPT_NAME enables easy management of your VPN Client connections for
-various VPN providers on AsusWRT-Merlin. The following VPN Providers are
-currently supported: NordVPN, Private Internet Access (PIA) and WeVPN.
-NordVPN clients can be configured to automatically refresh on a scheduled
-basis with the recommended server as provided by the NordVPN API.
+various VPN providers on AsusWRT-Merlin. Provider-specific logic is
+implemented in modular provider scripts under $PROVIDERS_DIR.
+The following VPN Providers are supported: NordVPN, Private Internet
+Access (PIA, unmaintained) and WeVPN (deprecated).
+VPN clients can be configured to automatically refresh on a scheduled
+basis using the recommended server from each provider's API.
 License
   $SCRIPT_NAME is free to use under the GNU General Public License
   version 3 (GPL-3.0) https://opensource.org/licenses/GPL-3.0
 Help & Support
   https://www.snbforums.com/forums/asuswrt-merlin-addons.60/?prefix_id=11
 Source code
-  https://github.com/jackyaz/$SCRIPT_NAME
+  https://github.com/h0me5k1n/$SCRIPT_NAME
 EOF
 	printf "\\n"
 }
@@ -2476,13 +2174,8 @@ if [ -z "$1" ]; then
 	Auto_Startup create 2>/dev/null
 	Auto_ServiceEvent create 2>/dev/null
 	Shortcut_Script create
-	if [ ! -f "$SCRIPT_DIR/nordvpn_countrydata" ]; then
-		getCountryData
-	fi
-	if [ "$(/usr/bin/find "$OVPN_ARCHIVE_DIR" -name "*.zip" | wc -l)" -lt 4 ]; then
-		getOVPNArchives
-	fi
-	
+	Refresh_Provider_Cache
+
 	Create_Symlinks
 	ScriptHeader
 	MainMenu
@@ -2504,8 +2197,7 @@ case "$1" in
 	refreshcacheddata)
 		NTP_Ready
 		Entware_Ready
-		getCountryData
-		getOVPNArchives
+		Refresh_Provider_Cache
 		exit 0
 	;;
 	startup)
@@ -2535,9 +2227,7 @@ case "$1" in
 			sleep 3
 			echo 'var refreshcacheddatastatus = "InProgress";' > /tmp/detect_vpnmgr.js
 			sleep 1
-			getCountryData
-			sleep 1
-			getOVPNArchives
+			Refresh_Provider_Cache
 			sleep 1
 			echo 'var refreshcacheddatastatus = "Done";' > /tmp/detect_vpnmgr.js
 			Clear_Lock
@@ -2546,10 +2236,11 @@ case "$1" in
 			rm -f /tmp/vpnmgrserverloads
 			for i in 1 2 3 4 5; do
 				VPN_CLIENTDESC="$(nvram get vpn_client"$i"_desc)"
-				if ! echo "$VPN_CLIENTDESC" | grep -iq "nordvpn"; then
-					continue
+				[ -z "$VPN_CLIENTDESC" ] && continue
+				VPN_PROV_LC="$(grep "vpn${i}_provider" "$SCRIPT_CONF" | cut -f2 -d"=" | tr 'A-Z' 'a-z')"
+				if Load_Provider "$VPN_PROV_LC" 2>/dev/null; then
+					printf "var vpn%s_serverload=%s;\\r\\n" "$i" "$("provider_${VPN_PROV_LC}_get_server_load" "$VPN_CLIENTDESC")" >> /tmp/vpnmgrserverloads.tmp
 				fi
-				printf "var vpn%s_serverload=%s;\\r\\n" "$i" "$(getServerLoad "$VPN_CLIENTDESC")" >> /tmp/vpnmgrserverloads.tmp
 			done
 			mv /tmp/vpnmgrserverloads.tmp /tmp/vpnmgrserverloads
 		elif [ "$2" = "start" ] && [ "$3" = "${SCRIPT_NAME}checkupdate" ]; then
@@ -2583,12 +2274,8 @@ case "$1" in
 		Auto_Startup create 2>/dev/null
 		Auto_ServiceEvent create 2>/dev/null
 		Shortcut_Script create
-		if [ ! -f "$SCRIPT_DIR/nordvpn_countrydata" ]; then
-			getCountryData
-		fi
-		if [ "$(/usr/bin/find "$OVPN_ARCHIVE_DIR" -name "*.zip" | wc -l)" -lt 4 ]; then
-			getOVPNArchives
-		fi
+		Install_Providers
+		Refresh_Provider_Cache
 		Create_Symlinks
 		exit 0
 	;;
@@ -2604,12 +2291,8 @@ case "$1" in
 		Auto_Startup create 2>/dev/null
 		Auto_ServiceEvent create 2>/dev/null
 		Shortcut_Script create
-		if [ ! -f "$SCRIPT_DIR/nordvpn_countrydata" ]; then
-			getCountryData
-		fi
-		if [ "$(/usr/bin/find "$OVPN_ARCHIVE_DIR" -name "*.zip" | wc -l)" -lt 4 ]; then
-			getOVPNArchives
-		fi
+		Install_Providers
+		Refresh_Provider_Cache
 		Create_Symlinks
 		exit 0
 	;;
@@ -2625,13 +2308,13 @@ case "$1" in
 	;;
 	develop)
 		SCRIPT_BRANCH="develop"
-		SCRIPT_REPO="https://raw.githubusercontent.com/jackyaz/$SCRIPT_NAME/$SCRIPT_BRANCH"
+		SCRIPT_REPO="https://raw.githubusercontent.com/h0me5k1n/$SCRIPT_NAME/$SCRIPT_BRANCH"
 		Update_Version force
 		exit 0
 	;;
 	stable)
 		SCRIPT_BRANCH="master"
-		SCRIPT_REPO="https://raw.githubusercontent.com/jackyaz/$SCRIPT_NAME/$SCRIPT_BRANCH"
+		SCRIPT_REPO="https://raw.githubusercontent.com/h0me5k1n/$SCRIPT_NAME/$SCRIPT_BRANCH"
 		Update_Version force
 		exit 0
 	;;

--- a/vpnmgr.sh
+++ b/vpnmgr.sh
@@ -30,7 +30,7 @@
 ### Start of script variables ###
 readonly SCRIPT_NAME="vpnmgr"
 readonly SCRIPT_VERSION="v2.3.2"
-SCRIPT_BRANCH="master"
+SCRIPT_BRANCH="main"
 SCRIPT_REPO="https://raw.githubusercontent.com/h0me5k1n/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME.d"
 readonly SCRIPT_CONF="$SCRIPT_DIR/config"
@@ -2313,7 +2313,7 @@ case "$1" in
 		exit 0
 	;;
 	stable)
-		SCRIPT_BRANCH="master"
+		SCRIPT_BRANCH="main"
 		SCRIPT_REPO="https://raw.githubusercontent.com/h0me5k1n/$SCRIPT_NAME/$SCRIPT_BRANCH"
 		Update_Version force
 		exit 0


### PR DESCRIPTION
## Summary

- Extracts all provider-specific logic from `vpnmgr.sh` into `providers/provider_<name>.sh` modules (NordVPN, PIA, WeVPN, template)
- Core dispatches to providers via `Load_Provider` / `provider_${name}_*` pattern — zero inline provider code in the core
- Adds `scripts/smoke-test.sh` (78 tests: syntax, shellcheck, contract completeness, repo hygiene, attribution, .gitignore coverage)
- Adds `.github/workflows/ci.yml` — PR/push workflow running the smoke test with shellcheck on Ubuntu
- Retires the jackyaz-era `shellcheck.yml` (now manual-only)
- Updates `.gitignore` to block accidental commits of provider config files (*.ovpn, *.zip, *.p12, *.pem)

## Test plan

- [ ] CI workflow passes (smoke-test job)
- [ ] `bash scripts/smoke-test.sh` passes locally (78/78)
- [ ] Provider modules load correctly on router: `vpnmgr update` downloads providers, VPN config applies