### PR TITLE
chore: Phase 3 — URL and branding sweep

### DIFF
--- a/vpnmgr.sh
+++ b/vpnmgr.sh
@@ -11,6 +11,7 @@
 ##                                                   ##
 ##       https://github.com/h0me5k1n/vpnmgr          ##
 ##     Originally by h0me5k1n, expanded by jackyaz   ##
+##     Revived and maintained by h0me5k1n            ##
 #######################################################
 
 ##########         Shellcheck directives     ##########


### PR DESCRIPTION
## Summary

- Adds \"Revived and maintained by h0me5k1n\" line to the script banner (the only script-side change needed)

## Audit findings

Everything else was already correct coming out of Phase 2:

| Item | Status |
|------|--------|
| `SCRIPT_REPO` | ✅ Already `h0me5k1n/vpnmgr` |
| Integrity check grep | ✅ Already greps for `h0me5k1n` |
| Donation links (PayPal/BuyMeACoffee) | ✅ None found anywhere |
| Banner | ✅ Fixed in this PR |
| `SHARED_REPO` (`jackyaz/shared-jy`) | ⏸ Deferred — WebUI-only wiring; `shared-jy` is archived and WebUI is being evaluated separately |

## Known deferred item

`vpnmgr.sh:42` — `SHARED_REPO` still points to `https://raw.githubusercontent.com/jackyaz/shared-jy/master`. This drives the WebUI's shared JS/CSS assets (jQuery, detect.js). Since `shared-jy` is archived and the WebUI itself is under evaluation, this is left for a dedicated WebUI phase rather than patched here.

## Test plan

- [x] `bash scripts/smoke-test.sh` — 78/78 passed
- [x] CI will run on this PR via `.github/workflows/ci.yml`