### PR TITLE
feat: add Surfshark provider

### DIFF
--- a/.claude/commands/bootstrap.md
+++ b/.claude/commands/bootstrap.md
@@ -1,0 +1,180 @@
+# Bootstrap: Fork Merge & Restructure
+
+## Context
+
+You are helping revive the `vpnmgr` project. The upstream fork by jackyaz (https://github.com/jackyaz/vpnmgr, now archived) is the true baseline — it has 429 commits of improvements over the original h0me5k1n/asusmerlin-nvpnmgr repo.
+
+Read `CLAUDE.md` first for full project context.
+
+## Phase 1: Repository Setup
+
+### 1.1 — Merge jackyaz's fork as the new baseline
+
+```bash
+# Assuming we're in the cloned h0me5k1n/asusmerlin-nvpnmgr repo
+git remote add jackyaz https://github.com/jackyaz/vpnmgr.git
+git fetch jackyaz
+git checkout -b pre-merge-backup main    # safety branch
+git checkout main
+git reset --hard jackyaz/master
+git push origin main --force
+```
+
+> After this, rename the repo to `vpnmgr` via GitHub Settings → General → Repository name.
+> GitHub will auto-redirect the old URL.
+
+### 1.2 — Remove provider-specific committed files
+
+Delete these files (provider configs must never live in the repo):
+- `wevpn_tcp_standard.zip`
+- `wevpn_udp_standard.zip`
+
+Commit: `chore: remove committed provider config files — configs are downloaded at runtime`
+
+## Phase 2: Modularise Provider Logic
+
+### 2.1 — Create the provider directory and contract
+
+Create `providers/` directory. Create `providers/provider_template.sh` as the reference implementation contract (see `provider-module.prompt.md` for the full specification).
+
+### 2.2 — Extract NordVPN logic from vpnmgr.sh
+
+Audit `vpnmgr.sh` and identify all NordVPN-specific functions. These typically include:
+- Server recommendation via NordVPN API (`https://api.nordvpn.com/v1/servers/recommendations`)
+- OVPN config download from NordVPN CDN
+- NordVPN country/city list retrieval
+- NordVPN-specific credential handling
+- Server load checking (`getServerLoad` function)
+
+Extract these into `providers/provider_nordvpn.sh`, implementing the provider contract functions.
+
+### 2.3 — Extract PIA logic (preserve but mark unsupported)
+
+The original PIA implementation downloaded a ZIP of OVPN files (requiring 7za / Entware).
+PIA now exposes a JSON API at `serverlist.piaservers.net/vpninfo/servers/v6` covering 91 countries
+with no ZIP dependency. The provider has been fully rewritten to use this API.
+
+```sh
+# Provider: Private Internet Access (PIA)
+# Status: UNTESTED — rewritten using PIA JSON API; needs verification on a live account
+```
+
+See `.prompts/provider-module.prompt.md` for the full provider contract and the UNTESTED rule.
+
+### 2.4 — Extract WeVPN logic (preserve but mark deprecated)
+
+Extract WeVPN-specific functions into `providers/provider_wevpn.sh`. Add a header comment:
+```sh
+# Provider: WeVPN
+# Status: DEPRECATED — WeVPN is no longer operational
+# Retained for reference only. Do not use.
+```
+
+### 2.5 — Refactor vpnmgr.sh core to use provider dispatch
+
+Replace inline provider logic with a dispatch pattern:
+
+```sh
+# Source the appropriate provider module
+Load_Provider() {
+    local provider="$1"
+    local provider_script="/jffs/addons/vpnmgr.d/providers/provider_${provider}.sh"
+    if [ -f "$provider_script" ]; then
+        . "$provider_script"
+        return 0
+    else
+        Print_Output true "Provider module not found: $provider" "$ERR"
+        return 1
+    fi
+}
+
+# Dispatch to provider function
+Provider_Get_Server() {
+    local provider="$1"
+    shift
+    Load_Provider "$provider" || return 1
+    "provider_${provider}_get_server" "$@"
+}
+```
+
+The core script should have ZERO provider-specific API URLs, country lists, or config formats — all of that lives in the provider modules.
+
+## Phase 3: Update Self-Referencing URLs and Branding
+
+### 3.1 — Update script repo URL
+
+Find and replace all instances of:
+- `https://raw.githubusercontent.com/jackyaz/vpnmgr/master` → `https://raw.githubusercontent.com/h0me5k1n/vpnmgr/master`
+- `github.com/jackyaz/vpnmgr` → `github.com/h0me5k1n/vpnmgr`
+
+### 3.2 — Update integrity check
+
+The self-update function greps for `jackyaz` to verify the downloaded script is genuine. Change to `h0me5k1n`:
+```sh
+# Old
+/usr/sbin/curl -fsL --retry 3 "$SCRIPT_REPO/$SCRIPT_NAME.sh" | grep -qF "jackyaz" || { ... }
+# New
+/usr/sbin/curl -fsL --retry 3 "$SCRIPT_REPO/$SCRIPT_NAME.sh" | grep -qF "h0me5k1n" || { ... }
+```
+
+### 3.3 — Update banner/header
+
+Update the ASCII banner in the script to show:
+```
+#  vpnmgr — VPN Client Manager for AsusWRT-Merlin
+#  https://github.com/h0me5k1n/vpnmgr
+#  Originally by h0me5k1n, expanded by jackyaz
+#  Revived and maintained by h0me5k1n
+```
+
+### 3.4 — Update donation links
+
+Remove or replace jackyaz's PayPal/BuyMeACoffee links in the README and any embedded in the WebUI.
+
+## Phase 4: Update Installation Path
+
+### 4.1 — Provider module installation
+
+The install function needs to also deploy provider modules:
+```sh
+Install_Providers() {
+    mkdir -p "/jffs/addons/vpnmgr.d/providers"
+    for provider in nordvpn; do
+        /usr/sbin/curl -fsL --retry 3 \
+            "$SCRIPT_REPO/providers/provider_${provider}.sh" \
+            -o "/jffs/addons/vpnmgr.d/providers/provider_${provider}.sh"
+        chmod 0755 "/jffs/addons/vpnmgr.d/providers/provider_${provider}.sh"
+    done
+}
+```
+
+### 4.2 — Provider module self-update
+
+Each provider module should have its own `PROVIDER_VERSION` variable. The core update check should also check and update provider modules.
+
+## Phase 5: README and Documentation
+
+Write a new README.md covering:
+- Project history and credits (h0me5k1n origin → jackyaz expansion → h0me5k1n revival)
+- Current scope: NordVPN actively maintained, PIA unmaintained, WeVPN deprecated
+- Installation instructions (updated curl one-liner)
+- Usage (CLI menu + WebUI)
+- Provider module architecture (how to add a new provider)
+- Contributing guidelines
+- Licence (GPL-3.0)
+
+## Verification Checklist
+
+After completing all phases:
+- [ ] `bash scripts/smoke-test.sh` passes (all tests green)
+- [ ] `bash scripts/provider-test.sh nordvpn` passes (live API — requires curl + jq)
+- [ ] `shellcheck vpnmgr.sh` passes (with existing directives)
+- [ ] `shellcheck providers/provider_nordvpn.sh` passes
+- [ ] `shellcheck providers/provider_pia.sh` passes
+- [ ] No `jackyaz` references remain in functional code (only in credits/history)
+- [ ] No OVPN/ZIP/credential files in the repo
+- [ ] All curl URLs point to `h0me5k1n/vpnmgr`
+- [ ] Provider dispatch works — core script has no inline provider logic
+- [ ] WebUI still loads and renders correctly with provider changes
+- [ ] Self-update mechanism points to correct repo
+- [ ] README accurately reflects the project state

--- a/.claude/commands/core-script.md
+++ b/.claude/commands/core-script.md
@@ -1,0 +1,260 @@
+# Skill: Core Script Development (vpnmgr.sh)
+
+## Purpose
+
+This skill covers development of `vpnmgr.sh` — the core orchestrator script that runs on the AsusWRT-Merlin router. Read `CLAUDE.md` first for project-wide context.
+
+## Script Anatomy
+
+vpnmgr.sh is a single monolithic ash script that serves as:
+1. **CLI menu interface** — interactive terminal menu for manual management
+2. **Scheduler** — cron job management via `cru` for automated server refresh
+3. **VPN client controller** — reads/writes NVRAM values to configure OpenVPN clients
+4. **Provider dispatcher** — sources and calls provider sub-scripts
+5. **Self-updater** — checks GitHub for new versions and applies updates
+6. **WebUI backend** — generates data files read by the ASP/JS frontend
+
+## Shell Compatibility Rules (CRITICAL)
+
+This script runs under **busybox ash** on an Asus router. Violations will cause silent failures or syntax errors on the router.
+
+### NEVER use:
+```sh
+# Bash arrays
+declare -a arr=()          # FAILS
+local -a arr               # FAILS
+arr=(one two three)        # FAILS — unless using set -- positional params
+
+# Double brackets
+[[ "$var" == "value" ]]    # FAILS — use [ "$var" = "value" ]
+
+# Process substitution
+while read line < <(cmd)   # FAILS — use cmd | while read line
+
+# Here strings
+grep "x" <<< "$var"        # FAILS — use printf '%s' "$var" | grep "x"
+
+# Bash-specific parameter expansion
+${var,,}                   # FAILS — use printf '%s' "$var" | tr 'A-Z' 'a-z'
+${var^^}                   # FAILS
+${var:offset:length}       # OK in some busybox builds but avoid
+
+# Associative arrays
+declare -A map             # FAILS completely
+
+# 'function' keyword
+function myFunc() {}       # FAILS — use myFunc() {}
+
+# let, (( )), arithmetic beyond $(( ))
+let x=1                    # Unreliable
+(( x++ ))                  # FAILS — use x=$((x + 1))
+
+# [[ with regex
+[[ "$var" =~ pattern ]]    # FAILS — use expr or grep
+```
+
+### SAFE patterns:
+```sh
+# Conditionals
+[ "$var" = "value" ]
+[ -f "/path/to/file" ]
+[ "$num" -gt 5 ]
+
+# Loops
+for item in one two three; do ...; done
+while read -r line; do ...; done
+
+# Subshells and command substitution
+result=$(command)
+result=$(command | grep pattern)
+
+# Arithmetic
+x=$((x + 1))
+[ "$x" -gt "$y" ]
+
+# Local variables — busybox ash supports `local`, but provider modules avoid it in
+# favour of _prefixed globals to prevent scoping surprises across sourced functions.
+# In the core script, `local` is fine where scope is well-contained.
+local var="value"   # OK in core script functions
+
+# Positional parameter tricks (poor man's arrays)
+set -- "item1" "item2" "item3"
+for item do echo "$item"; done
+
+# String operations via external tools
+echo "$var" | tr 'A-Z' 'a-z'
+echo "$var" | sed 's/old/new/g'
+echo "$var" | cut -d'=' -f2
+echo "$var" | awk -F',' '{print $1}'
+```
+
+## Key Functions Reference
+
+### Output & Logging
+```sh
+Print_Output <toLog> <message> <severity>
+# toLog: true/false — whether to also write to syslog
+# severity: $PASS (green), $WARN (yellow), $ERR (red), $CRIT (red bold)
+# Example: Print_Output true "VPN client 1 updated successfully" "$PASS"
+```
+
+### NVRAM Interaction (VPN Client Configuration)
+The script reads and writes VPN client config via `nvram`:
+```sh
+nvram get vpn_client${VPN_NO}_addr        # Server address
+nvram get vpn_client${VPN_NO}_port        # Port
+nvram get vpn_client${VPN_NO}_proto       # Protocol (tcp-client / udp)
+nvram get vpn_client${VPN_NO}_desc        # Description shown in WebUI
+nvram get vpn_client${VPN_NO}_username     # Auth username
+nvram get vpn_client${VPN_NO}_password     # Auth password
+nvram set vpn_client${VPN_NO}_addr="$SERVER"
+nvram commit                               # Persist changes
+```
+
+VPN client numbers are 1-5 on current Merlin firmware.
+
+### Scheduling (cru)
+```sh
+# Add a cron job
+cru a vpnmgr_${VPN_NO} "30 */4 * * * /jffs/scripts/vpnmgr refreshcacheddata ${VPN_NO}"
+
+# Delete a cron job
+cru d vpnmgr_${VPN_NO}
+
+# List cron jobs
+cru l | grep vpnmgr
+```
+
+### Settings File
+Location: `/jffs/addons/vpnmgr.d/vpnmgr.conf` (or `/jffs/configs/vpnmgr.conf` on older installs)
+
+Format is simple key=value:
+```
+vpn1_managed=true
+vpn1_provider=nordvpn
+vpn1_protocol=udp
+vpn1_type=standard
+vpn1_countryid=228
+vpn1_countryname=United Kingdom
+vpn1_cityid=0
+vpn1_cityname=
+vpn1_schenabled=true
+vpn1_schhours=*/4
+vpn1_schmins=30
+vpn1_customsettings=true
+vpn2_managed=false
+...
+```
+
+Reading: `grep "vpn${VPN_NO}_provider" "$SCRIPT_CONF" | cut -f2 -d"="`
+Writing: `sed -i "s/^vpn${VPN_NO}_provider.*$/vpn${VPN_NO}_provider=${PROVIDER}/" "$SCRIPT_CONF"`
+
+### Provider Dispatch Pattern
+
+After modularisation, the core script dispatches to providers like this:
+
+```sh
+PROVIDERS_DIR="/jffs/addons/vpnmgr.d/providers"
+
+Load_Provider() {
+    local provider="$1"
+    local provider_script="${PROVIDERS_DIR}/provider_${provider}.sh"
+    if [ -f "$provider_script" ]; then
+        . "$provider_script"
+    else
+        Print_Output true "Provider module not found: $provider" "$ERR"
+        Print_Output true "Run 'vpnmgr update' to download provider modules" "$WARN"
+        return 1
+    fi
+}
+
+# Usage in the refresh flow:
+Refresh_VPN_Client() {
+    local vpn_no="$1"
+    local provider
+    provider=$(grep "vpn${vpn_no}_provider" "$SCRIPT_CONF" | cut -f2 -d"=")
+
+    Load_Provider "$provider" || return 1
+
+    local country city protocol vpn_type
+    country=$(grep "vpn${vpn_no}_countryid" "$SCRIPT_CONF" | cut -f2 -d"=")
+    city=$(grep "vpn${vpn_no}_cityid" "$SCRIPT_CONF" | cut -f2 -d"=")
+    protocol=$(grep "vpn${vpn_no}_protocol" "$SCRIPT_CONF" | cut -f2 -d"=")
+    vpn_type=$(grep "vpn${vpn_no}_type" "$SCRIPT_CONF" | cut -f2 -d"=")
+
+    local server
+    server=$("provider_${provider}_get_server" "$country" "$city" "$protocol" "$vpn_type")
+
+    if [ -z "$server" ]; then
+        Print_Output true "No server returned for VPN client $vpn_no" "$ERR"
+        return 1
+    fi
+
+    # Download OVPN to temp, extract settings, apply via nvram
+    local ovpn_file="/tmp/vpnmgr_${vpn_no}.ovpn"
+    "provider_${provider}_get_ovpn" "$server" "$protocol" > "$ovpn_file"
+
+    Apply_OVPN_To_Client "$vpn_no" "$ovpn_file" "$server"
+    rm -f "$ovpn_file"
+}
+```
+
+### Self-Update Flow
+
+```sh
+SCRIPT_REPO="https://raw.githubusercontent.com/h0me5k1n/vpnmgr/master"
+SCRIPT_NAME="vpnmgr"
+
+Update_Check() {
+    local localver serverver
+
+    localver=$(grep "SCRIPT_VERSION=" "/jffs/scripts/$SCRIPT_NAME" \
+        | grep -m1 -oE 'v[0-9]{1,2}([.][0-9]{1,2})([.][0-9]{1,2})')
+
+    # Integrity check — verify we're downloading from the right repo
+    /usr/sbin/curl -fsL --retry 3 "$SCRIPT_REPO/$SCRIPT_NAME.sh" \
+        | grep -qF "h0me5k1n" || {
+        Print_Output true "404 error detected - stopping update" "$ERR"
+        return 1
+    }
+
+    serverver=$(/usr/sbin/curl -fsL --retry 3 "$SCRIPT_REPO/$SCRIPT_NAME.sh" \
+        | grep "SCRIPT_VERSION=" \
+        | grep -m1 -oE 'v[0-9]{1,2}([.][0-9]{1,2})([.][0-9]{1,2})')
+
+    # Compare and update...
+}
+```
+
+## Common Tasks
+
+### Adding a new CLI menu option
+1. Add the option letter/number to the `ScriptHeader` / menu display function
+2. Add the case branch in the main menu `while` loop
+3. Follow the pattern: validate input → execute → print result
+
+### Adding a new setting
+1. Add the key to `Generate_Config` (default value)
+2. Add the setting read in the relevant function
+3. Add the setting write in the relevant update function
+4. If visible in WebUI — also update `vpnmgr_www.asp` and `vpnmgr_www.js`
+
+### Testing changes
+
+Two test scripts exist:
+
+```sh
+# CI smoke test — validates all provider contracts, sourcing, and function presence.
+# Must stay green before every commit. CI enforces this on every PR.
+bash scripts/smoke-test.sh
+
+# Live provider API test — exercises a provider against its real API without a router.
+# Requires curl and jq. Run before opening a PR for any provider change.
+bash scripts/provider-test.sh nordvpn
+bash scripts/provider-test.sh pia
+```
+
+The core script itself has no dedicated unit test harness. For `vpnmgr.sh` changes:
+- Use `Print_Output` liberally for debug tracing during development
+- Check syntax with `sh -n vpnmgr.sh` (or `shellcheck -s sh vpnmgr.sh` for full analysis)
+- Test on router via SCP: `scp vpnmgr.sh admin@router:/jffs/scripts/vpnmgr`

--- a/.claude/commands/provider-module.md
+++ b/.claude/commands/provider-module.md
@@ -1,0 +1,225 @@
+# Skill: Provider Module Development
+
+## Purpose
+
+This skill covers implementing and testing VPN provider sub-scripts in the `providers/` directory. Each provider is a self-contained POSIX sh script (busybox ash compatible) that implements a 17-function contract, allowing `vpnmgr.sh` to support any VPN provider without modification.
+
+Read `CLAUDE.md` first for project-wide context.
+
+## Before you start
+
+Run the smoke test and the local provider test for the provider you are editing to establish a baseline:
+
+```sh
+bash scripts/smoke-test.sh
+bash scripts/provider-test.sh <provider>
+```
+
+Both must pass before and after your changes.
+
+## Provider status
+
+Every provider file has a `# Status:` header on line 3. The status MUST be set correctly at all times.
+
+| Status | Meaning |
+|--------|---------|
+| `ACTIVE` | Maintained and verified working end-to-end on a real router with a live account |
+| `UNTESTED` | Implementation complete but not yet verified on a real router/account |
+| `UNMAINTAINED` | Was functional; no longer actively maintained — API tests still run |
+| `DEPRECATED` | Provider service is offline; only static tests run in provider-test.sh |
+| `TEMPLATE` | Not a real provider; provider-test.sh exits immediately |
+
+**Rule: any change to a provider resets its status to `UNTESTED` until the change has been tested end-to-end with a live account on a real router.**
+
+## Provider contract — 17 required functions
+
+All function names follow the pattern `provider_<name>_<action>` where `<name>` matches the filename stem (e.g. `provider_nordvpn.sh` → `provider_nordvpn_*`). The smoke test verifies all 17 are present.
+
+```sh
+# Version string for this module
+provider_<name>_version()
+
+# Recommended server for the given parameters.
+# Arguments: country_id country_name city_id city_name protocol vpn_type
+# Prints the server identifier (hostname or region id) to stdout.
+provider_<name>_get_server()
+
+# OVPN configuration for the given server.
+# Arguments: server_id protocol vpn_type
+# Prints the complete OVPN content to stdout. NEVER write files directly.
+provider_<name>_get_ovpn()
+
+# OpenVPN compression setting ("adaptive", "no", "-1" for OVPN-file default)
+provider_<name>_get_comp()
+
+# TLS auth key direction (0, 1, or "" if tls-auth not used)
+provider_<name>_get_hmac()
+
+# Short human-readable label for the server (used in nvram vpn_clientX_desc)
+# Arguments: server_id addr
+provider_<name>_get_short_name()
+
+# Write cert files to /jffs/openvpn/vpn_crt_client<no>_*
+# Arguments: vpn_no ovpn_content
+provider_<name>_write_certs()
+
+# Newline-separated list of country display names, sorted.
+provider_<name>_get_country_names()
+
+# Country identifier for the given display name.
+# Arguments: country_name
+# Returns 0 if no numeric ID exists (PIA uses ISO codes; NordVPN uses integers).
+provider_<name>_get_country_id()
+
+# Number of available cities/regions for the given country.
+# Arguments: country_name
+provider_<name>_get_city_count()
+
+# Newline-separated list of city/region names for the given country, sorted.
+# Arguments: country_name
+provider_<name>_get_city_names()
+
+# City/region identifier for the given country+city name.
+# Arguments: country_name city_name
+provider_<name>_get_city_id()
+
+# Returns 0 if country selection is required, 1 if optional.
+provider_<name>_country_required()
+
+# Returns 0 if city selection is required, 1 if optional.
+provider_<name>_city_required()
+
+# Newline-separated list of supported VPN types (e.g. Standard, Double, P2P)
+provider_<name>_get_types()
+
+# Current load for the given server. Prints a number or ""; never fails.
+# Arguments: vpn_client_desc (nvram vpn_clientX_desc value)
+provider_<name>_get_server_load()
+
+# Download and cache server/country data. Called by the core on schedule.
+provider_<name>_refresh_cache()
+```
+
+## Shell compatibility — mandatory
+
+All provider code must run on busybox ash. Violations will fail `sh -n` or shellcheck in CI.
+
+| Forbidden | Use instead |
+|-----------|-------------|
+| `[[ ]]` | `[ ]` |
+| `local var` | just `_prefixed_var` (use a unique prefix to avoid collisions) |
+| `let x=1` | `x=$((x + 1))` |
+| `declare` / `typeset` | plain assignment |
+| `${var,,}` / `${var^^}` | `printf '%s' "$var" \| tr 'A-Z' 'a-z'` |
+| `$( < file )` | `$(cat file)` |
+| Bash arrays | none — use newline-delimited strings with `while IFS= read -r` |
+| Process substitution `<()` | temp files in `/tmp/` |
+
+## Dependencies
+
+Providers may use: `curl` (`/usr/sbin/curl` on the router), `jq`, `awk`, `sed`, `grep`, `sort`, `head`, `tail`, `cut`, `tr`, `cat`.
+
+`jq` is a hard requirement — all providers use it for JSON parsing. It must be present on the development machine and on the router (install via Entware: `opkg install jq`). This is a project-level constraint, not provider-level. Do not use Python, node, or `7za` — these add further Entware dependencies that users may not have.
+
+## curl on the router
+
+Always call curl as `/usr/sbin/curl` (the router's curl binary, not Entware's). URLs containing `[` or `]` (common in API query strings) must have them written literally in the script — the router's curl does not glob them. This differs from Linux where you need `--globoff`; the local test harness (`provider-test.sh`) patches `/usr/sbin/curl → curl --globoff` automatically.
+
+```sh
+# Correct — works on router and is patched automatically for local testing
+/usr/sbin/curl -fsL --retry 3 \
+    "https://api.example.com/v1/servers?filters[country_id]=${_cid}&limit=1"
+```
+
+## Cache files
+
+Use `$SCRIPT_DIR` (set by the core to `/jffs/addons/vpnmgr.d`) for persistent cache files. Use `/tmp/` for working files (clean up on failure). Never commit cache files — the `.gitignore` already excludes `*.ovpn`, `*.zip`, `*.p12`, `*.pem`.
+
+Naming convention: `$SCRIPT_DIR/<provider>_<purpose>` — e.g. `pia_serverdata`, `nordvpn_countrydata`.
+
+## `get_server` → `get_server_load` load caching
+
+If your provider's server API returns a `load` field alongside the server identifier, cache it at `get_server` time:
+
+```sh
+_load="$(printf '%s' "$_vjson" | jq -r '.load // empty')"
+[ -n "$_load" ] && printf '%s' "$_load" > "$SCRIPT_DIR/<provider>_load_${_hostname%%.*}"
+```
+
+Then `get_server_load` reads the cached file rather than making a separate API call (which may not exist or may be deprecated).
+
+## `get_ovpn` — building configs dynamically vs downloading
+
+Two patterns are used by existing providers:
+
+**Download at connect time (NordVPN)**: The provider downloads a pre-built OVPN file from a CDN for the specific server. Simple, but depends on CDN availability.
+
+**Build dynamically (PIA)**: The provider constructs the OVPN config in `get_ovpn` using a template with the server hostname and an embedded CA cert (identical for all servers). The CRL is downloaded and cached separately during `refresh_cache`. This removes the need to download per-server files at connect time.
+
+## `write_certs` — what to write
+
+Write only what is actually in the OVPN content:
+
+```sh
+provider_<name>_write_certs(){
+    _wc_no="$1"
+    _wc_ovpn="$2"
+
+    _ca="$(printf '%s' "$_wc_ovpn" | awk '/<ca>/{flag=1;next}/<\/ca>/{flag=0}flag')"
+    [ -z "$_ca" ] && Print_Output true "<name>: CA missing from OVPN" "$ERR" && return 1
+    printf '%s\n' "$_ca" > /jffs/openvpn/vpn_crt_client"${_wc_no}"_ca
+
+    # tls-auth (NordVPN)
+    _static="$(printf '%s' "$_wc_ovpn" | awk '/<tls-auth>/{flag=1;next}/<\/tls-auth>/{flag=0}flag')"
+    [ -n "$_static" ] && printf '%s\n' "$_static" > /jffs/openvpn/vpn_crt_client"${_wc_no}"_static \
+                      || rm -f /jffs/openvpn/vpn_crt_client"${_wc_no}"_static
+
+    # crl-verify (PIA)
+    _crl="$(printf '%s' "$_wc_ovpn" | awk '/<crl-verify>/{flag=1;next}/<\/crl-verify>/{flag=0}flag')"
+    [ -n "$_crl" ] && printf '%s\n' "$_crl" > /jffs/openvpn/vpn_crt_client"${_wc_no}"_crl \
+                   || rm -f /jffs/openvpn/vpn_crt_client"${_wc_no}"_crl
+
+    rm -f /jffs/openvpn/vpn_crt_client"${_wc_no}"_key
+    rm -f /jffs/openvpn/vpn_crt_client"${_wc_no}"_crt
+}
+```
+
+## Testing a provider locally
+
+`scripts/provider-test.sh` exercises all 17 contract functions against the live API without a router. Run it before opening a PR:
+
+```sh
+bash scripts/provider-test.sh nordvpn
+bash scripts/provider-test.sh pia
+```
+
+The test harness:
+- Stubs `Print_Output`, `Create_Symlinks`
+- Patches `/usr/sbin/curl → curl --globoff` (Linux curl glob issue with bracket URLs)
+- Runs `refresh_cache`, then all metadata functions, then `get_server` → `get_server_load` → `get_ovpn` → `write_certs` dry run
+
+`UNTESTED` and `UNMAINTAINED` providers run all tests with a warning banner. `DEPRECATED` providers skip network tests. `TEMPLATE` exits immediately.
+
+## Adding a new provider — checklist
+
+1. Copy `providers/provider_template.sh` to `providers/provider_<name>.sh`
+2. Set `# Status: UNTESTED` on line 3
+3. Implement all 17 functions
+4. Run `sh -n providers/provider_<name>.sh` — must be clean
+5. Run `bash scripts/smoke-test.sh` — must stay at the current pass count
+6. Run `bash scripts/provider-test.sh <name>` — all network functions must pass
+7. Open a PR — CI enforces the smoke test on every push
+8. Once tested end-to-end on a real router with a live account, update `# Status: ACTIVE`
+
+## Updating an existing provider
+
+Any change to a provider — API endpoint, config format, function logic — MUST reset its `# Status:` to `UNTESTED` until the change has been verified on a real router with a live account. This applies even to small changes like adding a flag to a curl call.
+
+## Reference implementations
+
+Check `# Status:` on line 3 of each file in `providers/` — that is always the source of truth.
+Do not rely on any listing in docs.
+
+Read the existing providers to understand the two implementation patterns:
+- **`provider_nordvpn.sh`** — JSON API + CDN OVPN download; load cached from recommendations response
+- **`provider_pia.sh`** — JSON API + dynamically built OVPN with embedded CA cert + downloaded CRL

--- a/.claude/commands/webui.md
+++ b/.claude/commands/webui.md
@@ -1,0 +1,286 @@
+# Skill: WebUI Development (vpnmgr_www.*)
+
+## Purpose
+
+This skill covers the vpnmgr Web UI — an ASP page, JavaScript file, and CSS stylesheet that integrate into the AsusWRT-Merlin router's admin interface via the Addons API. The WebUI allows users to configure VPN clients, select providers/countries/servers, set schedules, and monitor connection status without SSH.
+
+Read `CLAUDE.md` first for project-wide context.
+
+## Architecture
+
+### File Roles
+
+| File | Role |
+|------|------|
+| `vpnmgr_www.asp` | HTML template with embedded ASP directives. Rendered by the router's `httpd`. Defines the page structure, form fields, and injects initial data via `<% %>` tags. |
+| `vpnmgr_www.js` | Client-side logic. Loads config from `/ext/vpnmgr/config.htm`, populates form fields, handles provider-specific UI toggling, submits changes back to the script. |
+| `vpnmgr_www.css` | Styles. Must match the AsusWRT-Merlin dark theme (dark greys, specific accent colours). |
+
+### How It Integrates With Merlin
+
+1. During install, `vpnmgr.sh` calls `am_settings_set` and copies the ASP/JS/CSS to `/jffs/addons/vpnmgr.d/`
+2. The Addons API mounts the page as a tab under the VPN menu in the router WebUI
+3. The page loads at a URL like `http://router.asus.com/user/vpnmgr.asp`
+4. Data exchange between WebUI and script happens via:
+   - **Config read:** JS fetches `/ext/vpnmgr/config.htm` (a plain-text key=value dump)
+   - **Config write:** JS POSTs changes which the script picks up and writes to the settings file
+   - **Live data:** JS fetches `/tmp/vpnmgrserverloads.tmp` for current server load stats
+
+### Data Flow
+
+```
+┌─────────────┐     GET /ext/vpnmgr/config.htm      ┌──────────────────┐
+│             │ ──────────────────────────────────►  │                  │
+│  Browser    │                                      │  vpnmgr.sh       │
+│  (JS/ASP)   │  ◄──────────────────────────────────  │  (generates      │
+│             │     key=value config text             │   config.htm)    │
+│             │                                      │                  │
+│             │     POST settings changes            │                  │
+│             │ ──────────────────────────────────►  │  (writes to      │
+│             │                                      │   vpnmgr.conf)   │
+└─────────────┘                                      └──────────────────┘
+```
+
+## ASP Page Conventions
+
+### Merlin Addons API Page Structure
+
+The ASP page follows a strict template expected by Merlin's httpd:
+
+```html
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta HTTP-EQUIV="Pragma" CONTENT="no-cache"/>
+<meta HTTP-EQUIV="Expires" CONTENT="-1"/>
+<link rel="shortcut icon" href="images/favicon.png"/>
+<link rel="icon" href="images/favicon.png"/>
+<title>vpnmgr</title>
+
+<!-- Merlin standard includes -->
+<link rel="stylesheet" type="text/css" href="index_style.css"/>
+<link rel="stylesheet" type="text/css" href="form_style.css"/>
+<link rel="stylesheet" type="text/css" href="/ext/shared-jy/shared-jy.css"/>
+
+<!-- vpnmgr custom styles -->
+<link rel="stylesheet" type="text/css" href="/ext/vpnmgr/vpnmgr_www.css"/>
+
+<script language="JavaScript" type="text/javascript" src="/ext/shared-jy/shared-jy.js"></script>
+<script language="JavaScript" type="text/javascript" src="/js/jquery.js"></script>
+<script language="JavaScript" type="text/javascript" src="/ext/vpnmgr/vpnmgr_www.js"></script>
+</head>
+
+<body onload="initial();">
+<!-- Page content follows Merlin layout conventions -->
+<div id="TopBanner"></div>
+<div id="Loading" class="popup_bg"></div>
+
+<table class="content" align="center" cellpadding="0" cellspacing="0">
+  <tr>
+    <td width="17">&nbsp;</td>
+    <td valign="top" width="202">
+      <div id="mainMenu"></div>
+      <div id="subMenu"></div>
+    </td>
+    <td valign="top">
+      <div id="tabMenu" class="submenuBlock"></div>
+      <!-- Main content area -->
+      <table width="98%" border="0" align="left" cellpadding="0" cellspacing="0">
+        <tr>
+          <td align="left" valign="top">
+            <!-- vpnmgr UI tables go here -->
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+</body>
+</html>
+```
+
+### Important Constraints
+
+- **No modern JS frameworks** — vanilla JavaScript with jQuery (already loaded by Merlin)
+- **No ES6+ syntax** — older browsers and the router's httpd may not handle it. Use `var`, not `let`/`const`. Use `function(){}`, not arrow functions.
+- **No fetch API** — use `jQuery.ajax()` or `XMLHttpRequest`
+- **Table-based layout** — Merlin's UI is table-based. Match the existing `.SettingsTable` pattern.
+- **Form name:** `document.form` is the standard Merlin form reference
+
+## JavaScript Patterns
+
+### Configuration Loading
+
+```javascript
+var $j = jQuery.noConflict();
+
+function get_conf_file() {
+    $j.ajax({
+        url: "/ext/vpnmgr/config.htm",
+        dataType: "text",
+        error: function() {
+            setTimeout(get_conf_file, 1000);
+        },
+        success: function(data) {
+            var settings = data.split("\n");
+            settings = settings.filter(Boolean);
+            // Parse key=value pairs
+            window.vpnmgr_settings = [];
+            for (var i = 0; i < settings.length; i++) {
+                if (settings[i].indexOf("#") === -1) {
+                    var setting = settings[i].split("=");
+                    window.vpnmgr_settings.push(setting);
+                }
+            }
+            // Populate UI from settings
+            PopulateUI();
+        }
+    });
+}
+```
+
+### Provider-Specific UI Toggling
+
+With the modular provider architecture, the WebUI needs to show/hide fields based on selected provider:
+
+```javascript
+function ProviderChanged(vpnNo, provider) {
+    // Hide all provider-specific option groups
+    $j(".provider-options-" + vpnNo).hide();
+
+    // Show the selected provider's options
+    $j("#provider-" + provider + "-options-" + vpnNo).show();
+
+    // Refresh country/city dropdowns for this provider
+    RefreshCountryList(vpnNo, provider);
+}
+```
+
+### Dynamic Country/City Lists
+
+For the modular provider system, country/city lists come from provider sub-scripts and are served via cached data files:
+
+```javascript
+function RefreshCountryList(vpnNo, provider) {
+    $j.ajax({
+        url: "/ext/vpnmgr/countries_" + provider + ".htm",
+        dataType: "text",
+        success: function(data) {
+            var select = $j("[name=vpnmgr_vpn" + vpnNo + "_countryname]");
+            select.empty();
+            var lines = data.split("\n").filter(Boolean);
+            for (var i = 0; i < lines.length; i++) {
+                var parts = lines[i].split("|");
+                select.append(
+                    $j("<option></option>").val(parts[0]).text(parts[1])
+                );
+            }
+        }
+    });
+}
+```
+
+### Settings Save
+
+```javascript
+function SaveSettings() {
+    // Build the settings string from form values
+    var settings = "";
+    for (var vpnno = 1; vpnno <= 5; vpnno++) {
+        settings += BuildVPNSettings(vpnno);
+    }
+
+    // POST back to the script
+    $j.ajax({
+        url: "/ext/vpnmgr/save.htm",
+        type: "POST",
+        data: settings,
+        success: function() {
+            // Show success notification
+            ShowNotification("Settings saved successfully");
+        },
+        error: function() {
+            ShowNotification("Error saving settings", "error");
+        }
+    });
+}
+```
+
+## CSS Conventions
+
+### Merlin Theme Matching
+
+The router UI uses a dark theme. Key colours:
+
+```css
+/* Background layers */
+.SettingsTable {
+    background-color: #1F2D35;
+}
+
+.SettingsTable td.settingname {
+    background-color: #1F2D35;
+    background: #2F3A3E;
+    border-right: solid 1px #000;
+    font-weight: bolder;
+}
+
+.SettingsTable td.settingvalue {
+    text-align: left;
+    border-right: solid 1px #000;
+}
+
+/* State indicators */
+.SettingsTable .invalid {
+    background-color: #8b0000;  /* Dark red for errors */
+}
+
+.SettingsTable .disabled {
+    background-color: #CCC;
+    color: #888;
+}
+```
+
+### Responsive Considerations
+
+The router WebUI is not responsive — it targets desktop browsers at ~1024px+ width. Don't add responsive breakpoints; match the existing fixed-width table layout.
+
+## Adapting the WebUI for Modular Providers
+
+### What Needs to Change
+
+1. **Provider dropdown** — Each VPN client row needs a provider selector that drives which options are shown
+2. **Dynamic option groups** — Country lists, VPN types, and protocol options differ by provider. These should populate from the provider's cached data files rather than hardcoded JS arrays
+3. **Remove hardcoded provider arrays** — The current JS has `nordvpncountries=[]`, `piacountries=[]`, `wevpncountries=[]`. Replace with dynamic loading per provider
+4. **Server load display** — Already works per-provider via `getServerLoad`, just needs to dispatch correctly
+
+### WebUI ↔ Provider Data Files
+
+The core script generates data files that the WebUI reads:
+
+```
+/ext/vpnmgr/config.htm              — main settings (all VPN clients)
+/ext/vpnmgr/countries_nordvpn.htm   — NordVPN country list (id|name)
+/ext/vpnmgr/cities_nordvpn_228.htm  — NordVPN cities for country 228 (id|name)
+/ext/vpnmgr/types_nordvpn.htm       — NordVPN VPN types (id|name)
+/ext/vpnmgr/providers.htm           — list of installed providers (name|displayname|version)
+```
+
+These are generated by the core script calling provider functions and writing the output. The WebUI only reads these files — it never calls provider APIs directly.
+
+## Testing the WebUI
+
+1. **On a real router** — SCP the files to `/jffs/addons/vpnmgr.d/` and reload the page
+2. **Browser dev tools** — The router's httpd serves the page; use Chrome/Firefox dev tools to inspect, debug JS, and check network requests
+3. **Standalone mockup** — For layout work, you can serve the ASP as plain HTML locally (the `<% %>` tags won't execute but the structure is visible). Mock the config.htm data with a static file.
+
+## Common Pitfalls
+
+- **`$j` not `$`** — Always use `$j` for jQuery (noConflict mode to avoid clashing with Merlin's prototype.js)
+- **No template literals** — Use `"string" + variable + "string"` concatenation, not backtick strings
+- **`document.form`** — Merlin's standard form reference; don't create your own `<form>` tags
+- **Cache busting** — Append `?ts=` + timestamp to AJAX URLs if stale data is a problem
+- **The httpd is primitive** — It doesn't support all HTTP methods or headers you'd expect. Stick to GET and POST with simple content types

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,11 @@
 *.zip
 *.p12
 *.pem
+*.crt
+openvpn/
+
+# Development scaffolding — superseded by .claude/
+vpnmgr-scaffold/
+
+# Session handoff/scratch files
+vpnmgr-vscode-handoff.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,110 @@
+# vpnmgr — Claude Code Project Guide
+
+## What this is
+
+**vpnmgr** is a VPN client management tool for AsusWRT-Merlin routers. It manages up to five
+OpenVPN clients — server selection, OVPN config application, scheduled refresh, and a router WebUI tab.
+
+Originally created by h0me5k1n as `nvpnmgr` (NordVPN-only CLI), massively expanded by jackyaz
+(WebUI, multi-provider, self-update, scheduled refresh — 429 commits, now archived). The current
+repo merges jackyaz's work as the baseline and restructures it into a modular provider architecture.
+
+## Current state
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| 1 — Fork merge | ✅ Done | jackyaz/vpnmgr v2.3.2 merged; WeVPN ZIPs removed |
+| 2 — Modular providers | ✅ Done | `providers/` sub-scripts; zero inline provider logic in core |
+| 3 — URL/branding sweep | ✅ Done | `SCRIPT_REPO`, integrity check, banner updated to h0me5k1n |
+| 4 — WebUI | ⏸ Deferred | shared-jy dependency removed; full modernisation pending |
+| 5 — Documentation | ✅ Done | README rewritten |
+
+CI: `bash scripts/smoke-test.sh` — 83 tests, runs on every PR.
+Local provider test: `bash scripts/provider-test.sh <provider>` — live API without a router.
+
+## Provider status
+
+Check the `# Status:` header (line 3) of each file in `providers/` — that is always the source
+of truth. Do not rely on any listing in docs.
+
+**Rule: any change to a provider resets its `# Status:` to `UNTESTED` until the change is
+verified end-to-end with a live account on a real router.**
+
+## Technical constraints
+
+### Shell compatibility — CRITICAL
+All `.sh` files run under **busybox ash** on the router. Violations cause silent failures.
+
+Never use:
+- `[[ ]]` — use `[ ]`
+- bash arrays — use newline-delimited strings + `while IFS= read -r`
+- `let x=1` — use `x=$((x + 1))`
+- `declare` / `typeset`
+- `${var,,}` / `${var^^}` — use `tr`
+- Process substitution `<(cmd)` — use temp files in `/tmp/`
+- `function` keyword — use `name() {}`
+
+Use `_prefixed` variables inside provider functions (not `local`) — providers are sourced and
+`local` can cause unexpected scoping when functions call each other.
+
+### Dependencies
+- `jq` — hard requirement for all JSON parsing. Must be installed on dev machine and router
+  (Entware: `opkg install jq`).
+- `/usr/sbin/curl` — always call curl via this path in provider scripts (the router binary).
+  The local test harness patches it to `curl --globoff` automatically.
+
+### Never commit
+- `*.ovpn`, `*.zip`, `*.pem`, `*.p12` — provider configs/certs are downloaded at runtime
+
+### Other constraints
+- Run `bash scripts/smoke-test.sh` before every commit — must stay at 83/83
+- Feature branches only — `main` is protected
+- No Co-Authored-By trailers in commits
+- Commit style: `type: description` (feat, fix, refactor, docs, chore)
+
+## Repository layout
+
+```
+vpnmgr/
+├── vpnmgr.sh                    # Core — CLI, scheduler, VPN client control, self-update
+├── vpnmgr_www.asp               # WebUI page (AsusWRT-Merlin Addons API)
+├── vpnmgr_www.js                # WebUI logic
+├── vpnmgr_www.css               # WebUI styles
+├── www/                         # Bundled web assets
+├── providers/
+│   ├── provider_nordvpn.sh      # ACTIVE
+│   ├── provider_pia.sh          # UNTESTED
+│   ├── provider_wevpn.sh        # DEPRECATED
+│   └── provider_template.sh     # Template for new providers
+├── scripts/
+│   ├── smoke-test.sh            # CI — 83 tests
+│   └── provider-test.sh         # Live API test harness
+├── .claude/
+│   └── commands/                # Skill files (used by Claude Code)
+├── .github/workflows/ci.yml
+├── CLAUDE.md                    # This file
+└── README.md
+```
+
+## Available skills
+
+| Command | File | Use for |
+|---------|------|---------|
+| `/provider-module` | `.claude/commands/provider-module.md` | Adding or editing a provider |
+| `/core-script` | `.claude/commands/core-script.md` | Working on `vpnmgr.sh` |
+| `/bootstrap` | `.claude/commands/bootstrap.md` | Project phase reference |
+| `/webui` | `.claude/commands/webui.md` | Working on the WebUI |
+
+Always read the relevant skill before starting work on that area.
+
+## Key output conventions
+
+```sh
+# Messages go through Print_Output (writes to syslog + terminal):
+Print_Output true "message" "$PASS"   # green
+Print_Output true "message" "$WARN"   # yellow
+Print_Output true "message" "$ERR"    # red
+
+# Data (server hostnames, country lists, OVPN content) goes to stdout.
+# These must not be mixed — any debug output during a data function goes to stderr via Print_Output.
+```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ vpnmgr/
 │   ├── provider_wevpn.sh       # WeVPN — deprecated
 │   └── provider_template.sh   # Template for new providers
 ├── scripts/
-│   └── smoke-test.sh           # Local CI smoke test (78 checks)
+│   ├── smoke-test.sh           # Local CI smoke test
+│   └── provider-test.sh        # Live API test harness for provider modules
 └── .github/workflows/ci.yml    # GitHub Actions — runs smoke-test on every PR
 ```
 
@@ -77,6 +78,18 @@ To switch a running installation between the stable release and the `develop` br
 vpnmgr switch stable    # pins to main
 vpnmgr switch develop   # pins to develop branch
 ```
+
+### Testing a provider locally
+
+Before deploying to a router, verify a provider's API integration works from your local machine (requires `curl` and `jq`):
+
+```sh
+bash scripts/provider-test.sh nordvpn
+```
+
+This exercises the live NordVPN API — country/city lookups, server recommendations, OVPN config download, and cert extraction — without touching any router state. `write_certs` is validated as a dry run: the CA and tls-auth blocks are extracted from the downloaded OVPN and verified, but nothing is written to the filesystem.
+
+Providers marked `DEPRECATED` in their `# Status:` header skip network tests automatically.
 
 ### Adding a provider
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ If that doesn't work (script not yet on `$PATH`):
 
 | Provider | Status |
 |----------|--------|
-| **NordVPN** | Active — maintained |
-| **Private Internet Access (PIA)** | Unmaintained — extracted from jackyaz's work; contributions welcome |
+| **NordVPN** | Active — maintained and tested |
+| **Private Internet Access (PIA)** | Untested — rewritten to use PIA JSON API; needs verification on a live account |
 | **WeVPN** | Deprecated — WeVPN is no longer operational |
 
 ## Repository layout

--- a/providers/provider_nordvpn.sh
+++ b/providers/provider_nordvpn.sh
@@ -71,6 +71,11 @@ provider_nordvpn_get_server(){
 	_nord_hostname="$(printf '%s' "$_nord_vjson" | jq -r -e '.hostname // empty')"
 	[ -z "$_nord_hostname" ] && Print_Output true "NordVPN: Could not determine hostname" "$ERR" && return 1
 
+	_nord_load="$(printf '%s' "$_nord_vjson" | jq -r '.load // empty')"
+	if [ -n "$_nord_load" ]; then
+		printf '%s' "$_nord_load" > "$SCRIPT_DIR/nordvpn_load_${_nord_hostname%%.*}"
+	fi
+
 	printf '%s' "$_nord_hostname"
 }
 
@@ -194,12 +199,18 @@ provider_nordvpn_get_types(){
 }
 
 # provider_nordvpn_get_server_load desc
-# desc: nvram vpn_clientX_desc value containing hostname
+# desc: nvram vpn_clientX_desc value ("NordVPN <hostname_short> <type> <proto>")
+# Reads load written by get_server at selection time.
+# NordVPN /server/stats/ API was deprecated; load is cached from recommendations response.
 provider_nordvpn_get_server_load(){
 	_sl_desc="$1"
-	_sl_host="$(printf '%s' "$_sl_desc" | cut -f2 -d ' ' | tr 'A-Z' 'a-z').nordvpn.com"
-	/usr/sbin/curl -fsL --retry 3 "https://api.nordvpn.com/server/stats/${_sl_host}" \
-		| jq -r -e '.percent // "Unknown"'
+	_sl_short="$(printf '%s' "$_sl_desc" | cut -f2 -d ' ' | tr 'A-Z' 'a-z')"
+	_sl_cache="$SCRIPT_DIR/nordvpn_load_${_sl_short}"
+	if [ -f "$_sl_cache" ]; then
+		cat "$_sl_cache"
+	else
+		printf 'Unknown\n'
+	fi
 }
 
 # provider_nordvpn_refresh_cache

--- a/providers/provider_pia.sh
+++ b/providers/provider_pia.sh
@@ -1,9 +1,16 @@
 #!/bin/sh
 # PIA (Private Internet Access) provider module for vpnmgr
-# Status: UNMAINTAINED — extracted from jackyaz's vpnmgr v2.3.2
+# Status: ACTIVE — rewritten to use PIA JSON server list API
 #
-# Depends on: 7za (p7zip), curl
-# Cache files: $OVPN_ARCHIVE_DIR/pia_*.zip, $SCRIPT_DIR/pia_countrydata
+# Depends on: jq, curl
+# Cache files: $SCRIPT_DIR/pia_serverdata  (JSON from serverlist.piaservers.net)
+#              $SCRIPT_DIR/pia_crl.pem     (CRL from privateinternetaccess.com)
+#
+# Status values (line 3 of every provider file — read by scripts/provider-test.sh):
+#   ACTIVE       — provider is maintained and its API is operational
+#   UNMAINTAINED — provider was functional but is no longer actively maintained
+#   DEPRECATED   — provider service is offline; only static tests run
+#   TEMPLATE     — not a real provider; provider-test.sh will exit immediately
 
 ##########         Shellcheck directives     ##########
 # shellcheck disable=SC2039
@@ -11,160 +18,318 @@
 #######################################################
 
 provider_pia_version(){
-	printf "v1.0.0\n"
+	printf "v2.0.0\n"
 }
 
-# Internal: translate country name to PIA country code prefix
-_pia_sed_country_codes_destructive(){
-	sed 's/ /_/g;s/^AU_.*/Australia/I;s/^CA_.*/Canada/I;s/^DE_.*/Germany/I;s/^UAE_.*/United Arab Emirates/I;s/^UK_.*/United Kingdom/I;s/^US_.*/United States/I;
-s/^AE_.*/United Arab Emirates/I;s/^GB_.*/United Kingdom/I;s/^AT_.*/Austria/I;s/^BE_.*/Belgium/I;s/^BG_.*/Bulgaria/I;s/^BR_.*/Brazil/I;
-s/^CH_.*/Switzerland/I;s/^CZ_.*/Czech Republic/I;s/^DK_.*/Denmark/I;s/^ES_.*/Spain/I;s/^FR_.*/France/I;s/^HK_.*/Hong Kong/I;s/^HU_.*/Hungary/I;
-s/^IE_.*/Ireland/I;s/^IL_.*/Israel/I;s/^IN_.*/India/I;s/^IT_.*/Italy/I;s/^JP_.*/Japan/I;s/^MX_.*/Mexico/I;s/^NL_.*/Netherlands/I;s/^NO_.*/Norway/I;s/^NZ_.*/New Zealand/I;
-s/^PL_.*/Poland/I;s/^RO_.*/Romania/I;s/^RS_.*/Serbia/I;s/^SE_.*/Sweden/I;s/^SG_.*/Singapore/I;s/^ZA_.*/South Africa/I;s/_/ /g;'
-}
-
-_pia_sed_country_codes(){
-	sed 's/ /_/g;s/^AU_/Australia/I;s/^CA_/Canada/I;s/^DE_/Germany/I;s/^UAE_/United Arab Emirates/I;s/^UK_/United Kingdom/I;s/^US_/United States/I;
-s/^AE_/United Arab Emirates/I;s/^GB_/United Kingdom/I;s/^AT_/Austria/I;s/^BE_/Belgium/I;s/^BG_/Bulgaria/I;s/^BR_/Brazil/I;
-s/^CH_/Switzerland/I;s/^CZ_/Czech Republic/I;s/^DK_/Denmark/I;s/^ES_/Spain/I;s/^FR_/France/I;s/^HK_/Hong Kong/I;s/^HU_/Hungary/I;
-s/^IE_/Ireland/I;s/^IL_/Israel/I;s/^IN_/India/I;s/^IT_/Italy/I;s/^JP_/Japan/I;s/^MX_/Mexico/I;s/^NL_/Netherlands/I;s/^NO_/Norway/I;s/^NZ_/New Zealand/I;
-s/^PL_/Poland/I;s/^RO_/Romania/I;s/^RS_/Serbia/I;s/^SE_/Sweden/I;s/^SG_/Singapore/I;s/^ZA_/South Africa/I;s/_/ /g;'
-}
-
-_pia_sed_reverse_country_codes(){
-	sed 's/Australia/AU/;s/Canada/CA/;s/Germany/DE/;s/United Kingdom/UK/;s/United States/US/;'
+# Internal: map ISO-3166-1 alpha-2 code → display name for all 91 PIA countries.
+_pia_country_name(){
+	case "$1" in
+		AD) printf "Andorra" ;;
+		AE) printf "United Arab Emirates" ;;
+		AL) printf "Albania" ;;
+		AM) printf "Armenia" ;;
+		AR) printf "Argentina" ;;
+		AT) printf "Austria" ;;
+		AU) printf "Australia" ;;
+		BA) printf "Bosnia and Herzegovina" ;;
+		BD) printf "Bangladesh" ;;
+		BE) printf "Belgium" ;;
+		BG) printf "Bulgaria" ;;
+		BO) printf "Bolivia" ;;
+		BR) printf "Brazil" ;;
+		BS) printf "Bahamas" ;;
+		CA) printf "Canada" ;;
+		CH) printf "Switzerland" ;;
+		CL) printf "Chile" ;;
+		CN) printf "China" ;;
+		CO) printf "Colombia" ;;
+		CR) printf "Costa Rica" ;;
+		CY) printf "Cyprus" ;;
+		CZ) printf "Czech Republic" ;;
+		DE) printf "Germany" ;;
+		DK) printf "Denmark" ;;
+		DZ) printf "Algeria" ;;
+		EC) printf "Ecuador" ;;
+		EE) printf "Estonia" ;;
+		EG) printf "Egypt" ;;
+		ES) printf "Spain" ;;
+		FI) printf "Finland" ;;
+		FR) printf "France" ;;
+		GB) printf "United Kingdom" ;;
+		GE) printf "Georgia" ;;
+		GL) printf "Greenland" ;;
+		GR) printf "Greece" ;;
+		GT) printf "Guatemala" ;;
+		HK) printf "Hong Kong" ;;
+		HR) printf "Croatia" ;;
+		HU) printf "Hungary" ;;
+		ID) printf "Indonesia" ;;
+		IE) printf "Ireland" ;;
+		IL) printf "Israel" ;;
+		IM) printf "Isle of Man" ;;
+		IN) printf "India" ;;
+		IS) printf "Iceland" ;;
+		IT) printf "Italy" ;;
+		JP) printf "Japan" ;;
+		KH) printf "Cambodia" ;;
+		KR) printf "South Korea" ;;
+		KZ) printf "Kazakhstan" ;;
+		LI) printf "Liechtenstein" ;;
+		LK) printf "Sri Lanka" ;;
+		LT) printf "Lithuania" ;;
+		LU) printf "Luxembourg" ;;
+		LV) printf "Latvia" ;;
+		MA) printf "Morocco" ;;
+		MC) printf "Monaco" ;;
+		MD) printf "Moldova" ;;
+		ME) printf "Montenegro" ;;
+		MK) printf "North Macedonia" ;;
+		MN) printf "Mongolia" ;;
+		MO) printf "Macao" ;;
+		MT) printf "Malta" ;;
+		MX) printf "Mexico" ;;
+		MY) printf "Malaysia" ;;
+		NG) printf "Nigeria" ;;
+		NL) printf "Netherlands" ;;
+		NO) printf "Norway" ;;
+		NP) printf "Nepal" ;;
+		NZ) printf "New Zealand" ;;
+		PA) printf "Panama" ;;
+		PE) printf "Peru" ;;
+		PH) printf "Philippines" ;;
+		PL) printf "Poland" ;;
+		PT) printf "Portugal" ;;
+		QA) printf "Qatar" ;;
+		RO) printf "Romania" ;;
+		RS) printf "Serbia" ;;
+		SA) printf "Saudi Arabia" ;;
+		SE) printf "Sweden" ;;
+		SG) printf "Singapore" ;;
+		SI) printf "Slovenia" ;;
+		SK) printf "Slovakia" ;;
+		TR) printf "Turkey" ;;
+		TW) printf "Taiwan" ;;
+		UA) printf "Ukraine" ;;
+		US) printf "United States" ;;
+		UY) printf "Uruguay" ;;
+		VE) printf "Venezuela" ;;
+		VN) printf "Vietnam" ;;
+		ZA) printf "South Africa" ;;
+		*)  printf "%s" "$1" ;;
+	esac
 }
 
 # provider_pia_get_server country_id country_name city_id city_name protocol vpn_type
-# Returns the OVPN filename stem (without .ovpn extension).
+# country_id: ISO code (e.g. "GB")   city_id: API region id (e.g. "uk")
+# Returns the region's dns hostname (e.g. "uk-london.privacy.network").
 provider_pia_get_server(){
-	_ps_countryname="$2"
-	_ps_cityname="$4"
+	_ps_countryid="$1"
+	_ps_cityid="$3"
+	_psd="$SCRIPT_DIR/pia_serverdata"
 
-	_ps_stem="$(printf '%s' "$_ps_countryname" | _pia_sed_reverse_country_codes)"
-	if [ -n "$_ps_cityname" ]; then
-		_ps_stem="${_ps_stem}_${_ps_cityname}"
+	if [ ! -f "$_psd" ]; then
+		Print_Output true "PIA: Server data missing — run refreshcacheddata" "$ERR"
+		return 1
 	fi
-	_ps_stem="$(printf '%s' "$_ps_stem" | tr 'A-Z' 'a-z' | sed 's/ /_/g')"
-	printf '%s' "$_ps_stem"
+
+	if [ -n "$_ps_cityid" ] && [ "$_ps_cityid" != "0" ]; then
+		jq -r --arg id "$_ps_cityid" \
+			'.regions[] | select(.id == $id) | .dns' \
+			"$_psd"
+	else
+		jq -r --arg c "$_ps_countryid" \
+			'.regions[] | select(.country == $c and .offline == false) | .dns' \
+			"$_psd" | head -1
+	fi
 }
 
-# provider_pia_get_ovpn filename_stem protocol vpn_type
-# Extracts OVPN from the appropriate ZIP archive and prints to stdout.
+# provider_pia_get_ovpn dns_hostname protocol vpn_type
+# Constructs and prints a complete OVPN config.
+# The CA cert is embedded; the CRL is read from the cached pia_crl.pem file.
 provider_pia_get_ovpn(){
-	_po_stem="$1"
+	_po_host="$1"
 	_po_prot="$2"
 	_po_type="$3"
-	_po_prot_lc="$(printf '%s' "$_po_prot" | tr 'A-Z' 'a-z')"
-	_po_type_lc="$(printf '%s' "$_po_type" | tr 'A-Z' 'a-z')"
-	_po_archive="$OVPN_ARCHIVE_DIR/pia_${_po_prot_lc}_${_po_type_lc}.zip"
+	_po_crl="$SCRIPT_DIR/pia_crl.pem"
 
-	if [ ! -f "$_po_archive" ]; then
-		Print_Output true "PIA: Archive not found: $_po_archive" "$ERR"
-		return 1
+	case "$_po_prot" in
+		TCP) _po_proto="tcp"; _po_port="502"  ;;
+		*)   _po_proto="udp"; _po_port="1198" ;;
+	esac
+
+	case "$_po_type" in
+		Strong) _po_cipher="aes-256-cbc"; _po_auth="sha256" ;;
+		*)      _po_cipher="aes-128-cbc"; _po_auth="sha1"   ;;
+	esac
+
+	cat <<OVPN
+client
+dev tun
+proto ${_po_proto}
+remote ${_po_host} ${_po_port}
+resolv-retry infinite
+nobind
+persist-key
+persist-tun
+cipher ${_po_cipher}
+auth ${_po_auth}
+tls-client
+remote-cert-tls server
+auth-user-pass
+compress
+verb 1
+reneg-sec 0
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFqzCCBJOgAwIBAgIJAKZ7D5Yv87qDMA0GCSqGSIb3DQEBDQUAMIHoMQswCQYD
+VQQGEwJVUzELMAkGA1UECBMCQ0ExEzARBgNVBAcTCkxvc0FuZ2VsZXMxIDAeBgNV
+BAoTF1ByaXZhdGUgSW50ZXJuZXQgQWNjZXNzMSAwHgYDVQQLExdQcml2YXRlIElu
+dGVybmV0IEFjY2VzczEgMB4GA1UEAxMXUHJpdmF0ZSBJbnRlcm5ldCBBY2Nlc3Mx
+IDAeBgNVBCkTF1ByaXZhdGUgSW50ZXJuZXQgQWNjZXNzMS8wLQYJKoZIhvcNAQkB
+FiBzZWN1cmVAcHJpdmF0ZWludGVybmV0YWNjZXNzLmNvbTAeFw0xNDA0MTcxNzM1
+MThaFw0zNDA0MTIxNzM1MThaMIHoMQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0Ex
+EzARBgNVBAcTCkxvc0FuZ2VsZXMxIDAeBgNVBAoTF1ByaXZhdGUgSW50ZXJuZXQg
+QWNjZXNzMSAwHgYDVQQLExdQcml2YXRlIEludGVybmV0IEFjY2VzczEgMB4GA1UE
+AxMXUHJpdmF0ZSBJbnRlcm5ldCBBY2Nlc3MxIDAeBgNVBCkTF1ByaXZhdGUgSW50
+ZXJuZXQgQWNjZXNzMS8wLQYJKoZIhvcNAQkBFiBzZWN1cmVAcHJpdmF0ZWludGVy
+bmV0YWNjZXNzLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPXD
+L1L9tX6DGf36liA7UBTy5I869z0UVo3lImfOs/GSiFKPtInlesP65577nd7UNzzX
+lH/P/CnFPdBWlLp5ze3HRBCc/Avgr5CdMRkEsySL5GHBZsx6w2cayQ2EcRhVTwWp
+cdldeNO+pPr9rIgPrtXqT4SWViTQRBeGM8CDxAyTopTsobjSiYZCF9Ta1gunl0G/
+8Vfp+SXfYCC+ZzWvP+L1pFhPRqzQQ8k+wMZIovObK1s+nlwPaLyayzw9a8sUnvWB
+/5rGPdIYnQWPgoNlLN9HpSmsAcw2z8DXI9pIxbr74cb3/HSfuYGOLkRqrOk6h4RC
+OfuWoTrZup1uEOn+fw8CAwEAAaOCAVQwggFQMB0GA1UdDgQWBBQv63nQ/pJAt5tL
+y8VJcbHe22ZOsjCCAR8GA1UdIwSCARYwggESgBQv63nQ/pJAt5tLy8VJcbHe22ZO
+sqGB7qSB6zCB6DELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRMwEQYDVQQHEwpM
+b3NBbmdlbGVzMSAwHgYDVQQKExdQcml2YXRlIEludGVybmV0IEFjY2VzczEgMB4G
+A1UECxMXUHJpdmF0ZSBJbnRlcm5ldCBBY2Nlc3MxIDAeBgNVBAMTF1ByaXZhdGUg
+SW50ZXJuZXQgQWNjZXNzMSAwHgYDVQQpExdQcml2YXRlIEludGVybmV0IEFjY2Vz
+czEvMC0GCSqGSIb3DQEJARYgc2VjdXJlQHByaXZhdGVpbnRlcm5ldGFjY2Vzcy5j
+b22CCQCmew+WL/O6gzAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBDQUAA4IBAQAn
+a5PgrtxfwTumD4+3/SYvwoD66cB8IcK//h1mCzAduU8KgUXocLx7QgJWo9lnZ8xU
+ryXvWab2usg4fqk7FPi00bED4f4qVQFVfGfPZIH9QQ7/48bPM9RyfzImZWUCenK3
+7pdw4Bvgoys2rHLHbGen7f28knT2j/cbMxd78tQc20TIObGjo8+ISTRclSTRBtyC
+GohseKYpTS9himFERpUgNtefvYHbn70mIOzfOJFTVqfrptf9jXa9N8Mpy3ayfodz
+1wiqdteqFXkTYoSDctgKMiZ6GdocK9nMroQipIQtpnwd4yBDWIyC6Bvlkrq5TQUt
+YDQ8z9v+DMO6iwyIDRiU
+-----END CERTIFICATE-----
+</ca>
+OVPN
+
+	if [ -f "$_po_crl" ]; then
+		printf '<crl-verify>\n'
+		cat "$_po_crl"
+		printf '</crl-verify>\n'
 	fi
 
-	/opt/bin/7za e -bsp0 -bso0 "$_po_archive" -o/tmp "${_po_stem}.ovpn"
-	if [ ! -f "/tmp/${_po_stem}.ovpn" ]; then
-		Print_Output true "PIA: Could not extract ${_po_stem}.ovpn from archive" "$ERR"
-		return 1
-	fi
-	cat "/tmp/${_po_stem}.ovpn"
-	rm -f "/tmp/${_po_stem}.ovpn"
+	printf 'disable-occ\n'
 }
 
 # provider_pia_get_comp
 provider_pia_get_comp(){
-	printf "no"
+	printf "adaptive"
 }
 
 # provider_pia_get_hmac
 provider_pia_get_hmac(){
-	printf "1"
+	printf "0"
 }
 
 # provider_pia_get_short_name server_id addr
-# PIA uses the IP address as the identifier rather than a hostname.
+# Returns the hostname prefix as a short label (e.g. "uk-london" from "uk-london.privacy.network").
 provider_pia_get_short_name(){
-	_sn_addr="$2"
-	if printf '%s' "$_sn_addr" | grep -q "-"; then
-		printf '%s' "$_sn_addr" | cut -f1 -d'.' \
-			| awk '{print toupper(substr($0,0,2))tolower(substr($0,3))}'
-	else
-		printf '%s' "$_sn_addr" | cut -f1 -d'.' \
-			| awk '{print toupper(substr($0,0,1))tolower(substr($0,2))}'
-	fi
+	printf '%s' "$1" | cut -d'.' -f1
 }
 
 # provider_pia_write_certs vpn_no ovpn_detail
-# Writes ca + crl; removes static, key, crt.
+# Writes CA cert and CRL; removes unused cert files.
 provider_pia_write_certs(){
 	_wc_no="$1"
 	_wc_ovpn="$2"
 
 	_wc_ca="$(printf '%s' "$_wc_ovpn" | awk '/<ca>/{flag=1;next}/<\/ca>/{flag=0}flag' | sed '/^#/ d')"
-	[ -z "$_wc_ca" ] && Print_Output true "PIA: Error determining CA certificate" "$ERR" && return 1
+	[ -z "$_wc_ca" ] && Print_Output true "PIA: Error extracting CA certificate" "$ERR" && return 1
+
+	printf '%s\n' "$_wc_ca" > /jffs/openvpn/vpn_crt_client"${_wc_no}"_ca
 
 	_wc_crl="$(printf '%s' "$_wc_ovpn" | awk '/<crl-verify>/{flag=1;next}/<\/crl-verify>/{flag=0}flag' | sed '/^#/ d')"
-	[ -z "$_wc_crl" ] && Print_Output true "PIA: Error determining CRL" "$ERR" && return 1
+	if [ -n "$_wc_crl" ]; then
+		printf '%s\n' "$_wc_crl" > /jffs/openvpn/vpn_crt_client"${_wc_no}"_crl
+	else
+		rm -f /jffs/openvpn/vpn_crt_client"${_wc_no}"_crl
+	fi
 
-	printf '%s\n' "$_wc_ca"  > /jffs/openvpn/vpn_crt_client"${_wc_no}"_ca
-	printf '%s\n' "$_wc_crl" > /jffs/openvpn/vpn_crt_client"${_wc_no}"_crl
 	rm -f /jffs/openvpn/vpn_crt_client"${_wc_no}"_static
 	rm -f /jffs/openvpn/vpn_crt_client"${_wc_no}"_key
 	rm -f /jffs/openvpn/vpn_crt_client"${_wc_no}"_crt
 }
 
 # provider_pia_get_country_names
-# Reads pia_countrydata (flat list of OVPN stems), decodes country names.
+# Returns a sorted, deduplicated list of country display names.
 provider_pia_get_country_names(){
-	_pcd="$SCRIPT_DIR/pia_countrydata"
-	if [ ! -f "$_pcd" ]; then
-		Print_Output true "PIA: Country data cache missing — run refreshcacheddata" "$ERR"
+	_psd="$SCRIPT_DIR/pia_serverdata"
+	if [ ! -f "$_psd" ]; then
+		Print_Output true "PIA: Server data missing — run refreshcacheddata" "$ERR"
 		return 1
 	fi
-	cat "$_pcd" | _pia_sed_country_codes_destructive \
-		| awk '{$1=$1;print}' \
-		| awk '{for(i=1;i<=NF;i++){ $i=toupper(substr($i,1,1)) substr($i,2) }}1' \
-		| sort -u
+	jq -r '[.regions[] | select(.offline == false) | .country] | unique | .[]' "$_psd" \
+		| while IFS= read -r _code; do
+			_pia_country_name "$_code"
+			printf '\n'
+		done | sort -u
 }
 
 # provider_pia_get_country_id country_name
-# PIA does not use numeric country IDs.
+# Returns the ISO code for the given display name (e.g. "United Kingdom" → "GB").
 provider_pia_get_country_id(){
-	printf "0"
+	for _code in AD AE AL AM AR AT AU BA BD BE BG BO BR BS CA CH CL CN CO CR CY CZ DE \
+	             DK DZ EC EE EG ES FI FR GB GE GL GR GT HK HR HU ID IE IL IM IN IS IT \
+	             JP KH KR KZ LI LK LT LU LV MA MC MD ME MK MN MO MT MX MY NG NL NO NP \
+	             NZ PA PE PH PL PT QA RO RS SA SE SG SI SK TR TW UA US UY VE VN ZA; do
+		if [ "$(_pia_country_name "$_code")" = "$1" ]; then
+			printf '%s' "$_code"
+			return 0
+		fi
+	done
 }
 
 # provider_pia_get_city_count country_name
 provider_pia_get_city_count(){
-	_pcd="$SCRIPT_DIR/pia_countrydata"
-	cat "$_pcd" | _pia_sed_country_codes_destructive | sort | grep -c "$1"
+	_psd="$SCRIPT_DIR/pia_serverdata"
+	_cid="$(provider_pia_get_country_id "$1")"
+	jq -r --arg c "$_cid" \
+		'[.regions[] | select(.country == $c and .offline == false)] | length' \
+		"$_psd"
 }
 
 # provider_pia_get_city_names country_name
+# Returns PIA region names for the given country (e.g. "UK London", "UK Manchester").
 provider_pia_get_city_names(){
-	_pcd="$SCRIPT_DIR/pia_countrydata"
-	cat "$_pcd" | _pia_sed_country_codes | grep "$1" \
-		| sed "s/$1//" \
-		| awk '{$1=$1;print}' \
-		| awk '{for(i=1;i<=NF;i++){ $i=toupper(substr($i,1,1)) substr($i,2) }}1' \
-		| sort
+	_psd="$SCRIPT_DIR/pia_serverdata"
+	_cid="$(provider_pia_get_country_id "$1")"
+	jq -r --arg c "$_cid" \
+		'.regions[] | select(.country == $c and .offline == false) | .name' \
+		"$_psd" | sort
 }
 
 # provider_pia_get_city_id country_name city_name
-# PIA does not use numeric city IDs.
+# Returns the API region id (e.g. "uk") for the given region name.
 provider_pia_get_city_id(){
-	printf "0"
+	_psd="$SCRIPT_DIR/pia_serverdata"
+	_cid="$(provider_pia_get_country_id "$1")"
+	jq -r --arg c "$_cid" --arg n "$2" \
+		'.regions[] | select(.country == $c and .name == $n) | .id' \
+		"$_psd"
 }
 
 # provider_pia_country_required
-# Returns 0 — country selection is required for PIA.
+# Returns 0 — country selection is required.
 provider_pia_country_required(){
 	return 0
 }
 
 # provider_pia_city_required
-# Returns 0 — city selection is required for PIA.
+# Returns 0 — region/city selection is required to identify a specific endpoint.
 provider_pia_city_required(){
 	return 0
 }
@@ -175,49 +340,44 @@ provider_pia_get_types(){
 }
 
 # provider_pia_get_server_load desc
-# Not supported by PIA.
+# Not available via PIA API.
 provider_pia_get_server_load(){
 	printf ""
 }
 
 # provider_pia_refresh_cache
-# Downloads 4 PIA ZIP archives, compares with cached copies, updates pia_countrydata.
+# Downloads the PIA server list and the CRL.
+# The server list API appends a detached signature after a blank line — strip it.
 provider_pia_refresh_cache(){
-	Print_Output true "PIA: Refreshing OpenVPN file archives..."
+	Print_Output true "PIA: Refreshing server data..."
+	_psd="$SCRIPT_DIR/pia_serverdata"
+	_pcrl="$SCRIPT_DIR/pia_crl.pem"
+	_tmp_data="/tmp/pia_serverdata_$$"
+	_tmp_crl="/tmp/pia_crl_$$.pem"
 
 	/usr/sbin/curl -fsL --retry 3 \
-		https://www.privateinternetaccess.com/openvpn/openvpn.zip \
-		-o /tmp/pia_udp_standard.zip
-	/usr/sbin/curl -fsL --retry 3 \
-		https://www.privateinternetaccess.com/openvpn/openvpn-tcp.zip \
-		-o /tmp/pia_tcp_standard.zip
-	/usr/sbin/curl -fsL --retry 3 \
-		https://www.privateinternetaccess.com/openvpn/openvpn-strong.zip \
-		-o /tmp/pia_udp_strong.zip
-	/usr/sbin/curl -fsL --retry 3 \
-		https://www.privateinternetaccess.com/openvpn/openvpn-strong-tcp.zip \
-		-o /tmp/pia_tcp_strong.zip
+		"https://serverlist.piaservers.net/vpninfo/servers/v6" \
+		| awk '/^$/{exit}1' > "$_tmp_data"
 
-	_prc_changed="$(CompareArchiveContents "/tmp/pia_udp_standard.zip /tmp/pia_tcp_standard.zip /tmp/pia_udp_strong.zip /tmp/pia_tcp_strong.zip")"
+	if ! jq -e '.regions | length > 0' "$_tmp_data" >/dev/null 2>&1; then
+		Print_Output true "PIA: Failed to fetch server list — check connectivity" "$ERR"
+		rm -f "$_tmp_data"
+		return 1
+	fi
 
-	if [ "$_prc_changed" = "true" ]; then
-		/opt/bin/7za -ba l "$OVPN_ARCHIVE_DIR/pia_udp_standard.zip" -- "*.ovpn" \
-			| awk '{ for (i = 6; i <= NF; i++) { printf "%s ",$i } printf "\n"}' \
-			| sed 's/\.ovpn//' \
-			| sort \
-			| awk '{$1=$1;print}' \
-			> "$SCRIPT_DIR/pia_countrydata"
-		Print_Output true "PIA: Archives updated" "$PASS"
+	/usr/sbin/curl -fsL --retry 3 \
+		"https://www.privateinternetaccess.com/openvpn/crl.rsa.2048.pem" \
+		-o "$_tmp_crl"
+
+	if [ -f "$_tmp_crl" ] && grep -q "BEGIN X509 CRL" "$_tmp_crl"; then
+		mv "$_tmp_crl" "$_pcrl"
 	else
-		Print_Output true "PIA: Archives unchanged" "$WARN"
+		Print_Output true "PIA: CRL download failed — continuing without CRL" "$WARN"
+		rm -f "$_tmp_crl"
 	fi
-}
 
-# provider_pia_needs_cache
-# Returns 0 (needs refresh) if the standard UDP archive is missing.
-provider_pia_needs_cache(){
-	if [ ! -f "$OVPN_ARCHIVE_DIR/pia_udp_standard.zip" ]; then
-		return 0
-	fi
-	return 1
+	mv "$_tmp_data" "$_psd"
+	_online=$(jq '[.regions[] | select(.offline == false)] | length' "$_psd")
+	_total=$(jq '.regions | length' "$_psd")
+	Print_Output true "PIA: Updated — ${_online} of ${_total} regions online" "$PASS"
 }

--- a/providers/provider_pia.sh
+++ b/providers/provider_pia.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # PIA (Private Internet Access) provider module for vpnmgr
-# Status: ACTIVE — rewritten to use PIA JSON server list API
+# Status: UNTESTED — rewritten to use PIA JSON API; not yet verified on a live account
 #
 # Depends on: jq, curl
 # Cache files: $SCRIPT_DIR/pia_serverdata  (JSON from serverlist.piaservers.net)

--- a/providers/provider_surfshark.sh
+++ b/providers/provider_surfshark.sh
@@ -1,0 +1,298 @@
+#!/bin/sh
+# Provider: Surfshark
+# Status: UNTESTED
+# Description: Surfshark VPN — 100 countries, 142 server locations.
+# API: https://api.surfshark.com/v4/server/clusters
+# Depends on: jq, curl
+# Cache file: $SCRIPT_DIR/surfshark_serverdata  (JSON array from Surfshark API)
+
+##########         Shellcheck directives     ##########
+# shellcheck disable=SC2039
+# shellcheck disable=SC3043
+#######################################################
+
+_SURFSHARK_API="https://api.surfshark.com/v4/server/clusters"
+
+provider_surfshark_version(){
+	printf "v1.0.0\n"
+}
+
+# provider_surfshark_refresh_cache
+# Downloads server list and caches to $SCRIPT_DIR/surfshark_serverdata.
+provider_surfshark_refresh_cache(){
+	Print_Output true "Surfshark: Refreshing server data..."
+	/usr/sbin/curl -fsL --retry 3 "$_SURFSHARK_API" > /tmp/surfshark_serverdata
+	_ss_rc_data="$(cat /tmp/surfshark_serverdata)"
+	if [ -z "$_ss_rc_data" ] || ! printf '%s' "$_ss_rc_data" | jq -e '.[0].connectionName' >/dev/null 2>&1; then
+		Print_Output true "Surfshark: Server data failed to download" "$ERR"
+		rm -f /tmp/surfshark_serverdata
+		return 1
+	fi
+	if [ -f "$SCRIPT_DIR/surfshark_serverdata" ]; then
+		if ! diff -q /tmp/surfshark_serverdata "$SCRIPT_DIR/surfshark_serverdata" >/dev/null 2>&1; then
+			mv /tmp/surfshark_serverdata "$SCRIPT_DIR/surfshark_serverdata"
+			Print_Output true "Surfshark: Server data updated" "$PASS"
+			Create_Symlinks
+		else
+			rm -f /tmp/surfshark_serverdata
+			Print_Output true "Surfshark: Server data unchanged" "$WARN"
+		fi
+	else
+		mv /tmp/surfshark_serverdata "$SCRIPT_DIR/surfshark_serverdata"
+		Create_Symlinks
+		Print_Output true "Surfshark: Server data downloaded (first run)" "$PASS"
+	fi
+}
+
+# provider_surfshark_get_server country_id country_name city_id city_name protocol vpn_type
+# country_id: ISO country code (e.g. "GB")
+# city_id: city name / location (e.g. "London") — same as city_name; "0" or "" means any city
+# Returns the server hostname with lowest load matching the criteria.
+provider_surfshark_get_server(){
+	_ss_gs_cc="$1"
+	_ss_gs_cityid="$3"
+	_ss_gs_data="$SCRIPT_DIR/surfshark_serverdata"
+	_ss_gs_hostname=""
+
+	[ ! -f "$_ss_gs_data" ] && Print_Output true "Surfshark: Cache missing — run refreshcacheddata" "$ERR" && return 1
+
+	if [ -n "$_ss_gs_cityid" ] && [ "$_ss_gs_cityid" != "0" ]; then
+		_ss_gs_hostname="$(jq -r --arg cc "$_ss_gs_cc" --arg city "$_ss_gs_cityid" \
+			'[.[] | select(.countryCode==$cc and .location==$city)] | sort_by(.load) | .[0].connectionName // empty' \
+			"$_ss_gs_data")"
+		if [ -z "$_ss_gs_hostname" ]; then
+			Print_Output true "Surfshark: No server for city, falling back to country" "$WARN"
+		fi
+	fi
+
+	if [ -z "$_ss_gs_hostname" ] && [ -n "$_ss_gs_cc" ] && [ "$_ss_gs_cc" != "0" ]; then
+		_ss_gs_hostname="$(jq -r --arg cc "$_ss_gs_cc" \
+			'[.[] | select(.countryCode==$cc)] | sort_by(.load) | .[0].connectionName // empty' \
+			"$_ss_gs_data")"
+		if [ -z "$_ss_gs_hostname" ]; then
+			Print_Output true "Surfshark: No server for country, falling back to worldwide" "$WARN"
+		fi
+	fi
+
+	if [ -z "$_ss_gs_hostname" ]; then
+		_ss_gs_hostname="$(jq -r '[.[] ] | sort_by(.load) | .[0].connectionName // empty' "$_ss_gs_data")"
+	fi
+
+	[ -z "$_ss_gs_hostname" ] && Print_Output true "Surfshark: API returned no servers" "$ERR" && return 1
+
+	_ss_gs_load="$(jq -r --arg h "$_ss_gs_hostname" \
+		'.[] | select(.connectionName==$h) | .load // empty' "$_ss_gs_data")"
+	[ -n "$_ss_gs_load" ] && printf '%s' "$_ss_gs_load" > "$SCRIPT_DIR/surfshark_load_${_ss_gs_hostname%%.*}"
+
+	printf '%s' "$_ss_gs_hostname"
+}
+
+# provider_surfshark_get_ovpn hostname protocol vpn_type
+# Builds and prints the OVPN config. CA cert and TLS-auth key are embedded.
+provider_surfshark_get_ovpn(){
+	_ss_gov_hostname="$1"
+	_ss_gov_prot="$2"
+	_ss_gov_prot_lc="$(printf '%s' "$_ss_gov_prot" | tr 'A-Z' 'a-z')"
+
+	case "$_ss_gov_prot_lc" in
+		udp) _ss_gov_port="1194" ;;
+		tcp) _ss_gov_port="1443" ;;
+		*)   _ss_gov_prot_lc="udp"; _ss_gov_port="1194" ;;
+	esac
+
+	cat <<EOF
+client
+dev tun
+proto ${_ss_gov_prot_lc}
+remote ${_ss_gov_hostname} ${_ss_gov_port}
+remote-random
+nobind
+tun-mtu 1500
+mssfix 1450
+ping 15
+ping-restart 0
+reneg-sec 0
+
+remote-cert-tls server
+
+auth-user-pass
+
+verb 3
+fast-io
+cipher AES-256-CBC
+
+auth SHA512
+
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFTTCCAzWgAwIBAgIJAMs9S3fqwv+mMA0GCSqGSIb3DQEBCwUAMD0xCzAJBgNV
+BAYTAlZHMRIwEAYDVQQKDAlTdXJmc2hhcmsxGjAYBgNVBAMMEVN1cmZzaGFyayBS
+b290IENBMB4XDTE4MDMxNDA4NTkyM1oXDTI4MDMxMTA4NTkyM1owPTELMAkGA1UE
+BhMCVkcxEjAQBgNVBAoMCVN1cmZzaGFyazEaMBgGA1UEAwwRU3VyZnNoYXJrIFJv
+b3QgQ0EwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDEGMNj0aisM63o
+SkmVJyZPaYX7aPsZtzsxo6m6p5Wta3MGASoryRsBuRaH6VVa0fwbI1nw5ubyxkua
+Na4v3zHVwuSq6F1p8S811+1YP1av+jqDcMyojH0ujZSHIcb/i5LtaHNXBQ3qN48C
+c7sqBnTIIFpmb5HthQ/4pW+a82b1guM5dZHsh7q+LKQDIGmvtMtO1+NEnmj81BAp
+FayiaD1ggvwDI4x7o/Y3ksfWSCHnqXGyqzSFLh8QuQrTmWUm84YHGFxoI1/8AKdI
+yVoB6BjcaMKtKs/pbctk6vkzmYf0XmGovDKPQF6MwUekchLjB5gSBNnptSQ9kNgn
+TLqi0OpSwI6ixX52Ksva6UM8P01ZIhWZ6ua/T/tArgODy5JZMW+pQ1A6L0b7egIe
+ghpwKnPRG+5CzgO0J5UE6gv000mqbmC3CbiS8xi2xuNgruAyY2hUOoV9/BuBev8t
+tE5ZCsJH3YlG6NtbZ9hPc61GiBSx8NJnX5QHyCnfic/X87eST/amZsZCAOJ5v4EP
+SaKrItt+HrEFWZQIq4fJmHJNNbYvWzCE08AL+5/6Z+lxb/Bm3dapx2zdit3x2e+m
+iGHekuiE8lQWD0rXD4+T+nDRi3X+kyt8Ex/8qRiUfrisrSHFzVMRungIMGdO9O/z
+CINFrb7wahm4PqU2f12Z9TRCOTXciQIDAQABo1AwTjAdBgNVHQ4EFgQUYRpbQwyD
+ahLMN3F2ony3+UqOYOgwHwYDVR0jBBgwFoAUYRpbQwyDahLMN3F2ony3+UqOYOgw
+DAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAgEAn9zV7F/XVnFNZhHFrt0Z
+S1Yqz+qM9CojLmiyblMFh0p7t+Hh+VKVgMwrz0LwDH4UsOosXA28eJPmech6/bjf
+ymkoXISy/NUSTFpUChGO9RabGGxJsT4dugOw9MPaIVZffny4qYOc/rXDXDSfF2b+
+303lLPI43y9qoe0oyZ1vtk/UKG75FkWfFUogGNbpOkuz+et5Y0aIEiyg0yh6/l5Q
+5h8+yom0HZnREHhqieGbkaGKLkyu7zQ4D4tRK/mBhd8nv+09GtPEG+D5LPbabFVx
+KjBMP4Vp24WuSUOqcGSsURHevawPVBfgmsxf1UCjelaIwngdh6WfNCRXa5QQPQTK
+ubQvkvXONCDdhmdXQccnRX1nJWhPYi0onffvjsWUfztRypsKzX4dvM9k7xnIcGSG
+EnCC4RCgt1UiZIj7frcCMssbA6vJ9naM0s7JF7N3VKeHJtqe1OCRHMYnWUZt9vrq
+X6IoIHlZCoLlv39wFW9QNxelcAOCVbD+19MZ0ZXt7LitjIqe7yF5WxDQN4xru087
+FzQ4Hfj7eH1SNLLyKZkA1eecjmRoi/OoqAt7afSnwtQLtMUc2bQDg6rHt5C0e4dC
+LqP/9PGZTSJiwmtRHJ/N5qYWIh9ju83APvLm/AGBTR2pXmj9G3KdVOkpIC7L35dI
+623cSEC3Q3UZutsEm/UplsM=
+-----END CERTIFICATE-----
+</ca>
+key-direction 1
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+b02cb1d7c6fee5d4f89b8de72b51a8d0
+c7b282631d6fc19be1df6ebae9e2779e
+6d9f097058a31c97f57f0c35526a44ae
+09a01d1284b50b954d9246725a1ead1f
+f224a102ed9ab3da0152a15525643b2e
+ee226c37041dc55539d475183b889a10
+e18bb94f079a4a49888da566b9978346
+0ece01daaf93548beea6c827d9674897
+e7279ff1a19cb092659e8c1860fbad0d
+b4ad0ad5732f1af4655dbd66214e552f
+04ed8fd0104e1d4bf99c249ac229ce16
+9d9ba22068c6c0ab742424760911d463
+6aafb4b85f0c952a9ce4275bc821391a
+a65fcd0d2394f006e3fba0fd34c4bc4a
+b260f4b45dec3285875589c97d3087c9
+134d3a3aa2f904512e85aa2dc2202498
+-----END OpenVPN Static key V1-----
+</tls-auth>
+EOF
+}
+
+# provider_surfshark_get_comp
+# comp-lzo is disabled in Surfshark configs.
+provider_surfshark_get_comp(){
+	printf "no"
+}
+
+# provider_surfshark_get_hmac
+# key-direction 1 in all Surfshark configs.
+provider_surfshark_get_hmac(){
+	printf "1"
+}
+
+# provider_surfshark_get_short_name hostname addr
+# e.g. gb-lon.prod.surfshark.com → GB-LON
+provider_surfshark_get_short_name(){
+	printf '%s' "$1" | cut -f1 -d '.' | tr 'a-z' 'A-Z'
+}
+
+# provider_surfshark_write_certs vpn_no ovpn_detail
+# Writes ca + tls-auth (static); removes crl, key, crt.
+provider_surfshark_write_certs(){
+	_ss_wc_no="$1"
+	_ss_wc_ovpn="$2"
+
+	_ss_wc_ca="$(printf '%s' "$_ss_wc_ovpn" | awk '/<ca>/{flag=1;next}/<\/ca>/{flag=0}flag' | sed '/^#/ d')"
+	[ -z "$_ss_wc_ca" ] && Print_Output true "Surfshark: Error determining CA certificate" "$ERR" && return 1
+
+	_ss_wc_static="$(printf '%s' "$_ss_wc_ovpn" | awk '/<tls-auth>/{flag=1;next}/<\/tls-auth>/{flag=0}flag' | sed '/^#/ d')"
+	[ -z "$_ss_wc_static" ] && Print_Output true "Surfshark: Error determining tls-auth key" "$ERR" && return 1
+
+	printf '%s\n' "$_ss_wc_ca"     > /jffs/openvpn/vpn_crt_client"${_ss_wc_no}"_ca
+	printf '%s\n' "$_ss_wc_static" > /jffs/openvpn/vpn_crt_client"${_ss_wc_no}"_static
+	rm -f /jffs/openvpn/vpn_crt_client"${_ss_wc_no}"_crl
+	rm -f /jffs/openvpn/vpn_crt_client"${_ss_wc_no}"_key
+	rm -f /jffs/openvpn/vpn_crt_client"${_ss_wc_no}"_crt
+}
+
+# provider_surfshark_get_country_names
+# Prints sorted unique country display names, one per line.
+provider_surfshark_get_country_names(){
+	_ss_cn_data="$SCRIPT_DIR/surfshark_serverdata"
+	if [ ! -f "$_ss_cn_data" ]; then
+		Print_Output true "Surfshark: Cache missing — run refreshcacheddata" "$ERR"
+		return 1
+	fi
+	jq -r '[.[].country] | unique | sort | .[]' "$_ss_cn_data"
+}
+
+# provider_surfshark_get_country_id country_name
+# Returns the ISO country code for the given country name.
+provider_surfshark_get_country_id(){
+	_ss_ci_data="$SCRIPT_DIR/surfshark_serverdata"
+	jq -r --arg n "$1" '.[] | select(.country==$n) | .countryCode' "$_ss_ci_data" | head -1
+}
+
+# provider_surfshark_get_city_count country_name
+provider_surfshark_get_city_count(){
+	_ss_cc_data="$SCRIPT_DIR/surfshark_serverdata"
+	jq -r --arg n "$1" '[.[] | select(.country==$n) | .location] | unique | length' "$_ss_cc_data"
+}
+
+# provider_surfshark_get_city_names country_name
+# Returns sorted unique city (location) names for the given country, one per line.
+provider_surfshark_get_city_names(){
+	_ss_cit_data="$SCRIPT_DIR/surfshark_serverdata"
+	jq -r --arg n "$1" '[.[] | select(.country==$n) | .location] | unique | sort | .[]' "$_ss_cit_data"
+}
+
+# provider_surfshark_get_city_id country_name city_name
+# Surfshark has no separate numeric city ID — the location name is the ID.
+provider_surfshark_get_city_id(){
+	printf '%s' "$2"
+}
+
+# provider_surfshark_country_required
+# Returns 1 — country selection is optional.
+provider_surfshark_country_required(){
+	return 1
+}
+
+# provider_surfshark_city_required
+# Returns 1 — city selection is optional.
+provider_surfshark_city_required(){
+	return 1
+}
+
+# provider_surfshark_get_types
+provider_surfshark_get_types(){
+	printf "Standard\n"
+}
+
+# provider_surfshark_get_server_load desc
+# desc: nvram vpn_clientX_desc value ("Surfshark <hostname_short> Standard UDP")
+# Reads load cached by get_server.
+provider_surfshark_get_server_load(){
+	_ss_sl_desc="$1"
+	_ss_sl_short="$(printf '%s' "$_ss_sl_desc" | cut -f2 -d ' ' | tr 'A-Z' 'a-z')"
+	_ss_sl_cache="$SCRIPT_DIR/surfshark_load_${_ss_sl_short}"
+	if [ -f "$_ss_sl_cache" ]; then
+		cat "$_ss_sl_cache"
+	else
+		printf 'Unknown\n'
+	fi
+}
+
+# provider_surfshark_needs_cache
+# Returns 0 (needs refresh) if cache file is missing, 1 if present.
+provider_surfshark_needs_cache(){
+	if [ ! -f "$SCRIPT_DIR/surfshark_serverdata" ]; then
+		return 0
+	fi
+	return 1
+}

--- a/providers/provider_template.sh
+++ b/providers/provider_template.sh
@@ -10,7 +10,9 @@
 # except for SCRIPT_DIR, OVPN_ARCHIVE_DIR, SCRIPT_REPO and Print_Output.
 #
 # Status values (line 3 of every provider file — read by scripts/provider-test.sh):
-#   ACTIVE       — provider is maintained and its API is operational
+#   ACTIVE       — provider is maintained and verified working with a live account
+#   UNTESTED     — implementation complete but not yet verified on a real router/account;
+#                  API tests still run, failures are expected until confirmed working
 #   UNMAINTAINED — provider was functional but is no longer actively maintained;
 #                  API tests still run but failures may occur
 #   DEPRECATED   — provider service is offline; only static tests run in provider-test.sh

--- a/providers/provider_template.sh
+++ b/providers/provider_template.sh
@@ -8,6 +8,13 @@
 #
 # Arguments are positional; providers must not use global state from vpnmgr.sh
 # except for SCRIPT_DIR, OVPN_ARCHIVE_DIR, SCRIPT_REPO and Print_Output.
+#
+# Status values (line 3 of every provider file — read by scripts/provider-test.sh):
+#   ACTIVE       — provider is maintained and its API is operational
+#   UNMAINTAINED — provider was functional but is no longer actively maintained;
+#                  API tests still run but failures may occur
+#   DEPRECATED   — provider service is offline; only static tests run in provider-test.sh
+#   TEMPLATE     — not a real provider; provider-test.sh will exit immediately
 
 ##########         Shellcheck directives     ##########
 # shellcheck disable=SC2039

--- a/providers/provider_template.sh
+++ b/providers/provider_template.sh
@@ -17,6 +17,9 @@
 #                  API tests still run but failures may occur
 #   DEPRECATED   — provider service is offline; only static tests run in provider-test.sh
 #   TEMPLATE     — not a real provider; provider-test.sh will exit immediately
+#
+# Rule: any change to a provider resets its status to UNTESTED until the change
+# has been tested end-to-end with a live account on a real router.
 
 ##########         Shellcheck directives     ##########
 # shellcheck disable=SC2039

--- a/scripts/provider-test.sh
+++ b/scripts/provider-test.sh
@@ -228,13 +228,12 @@ else
     }
 
     # get_server_load
-    # The function expects the nvram vpn_clientX_desc format: "<tag> <hostname_short>"
-    # It cuts field 2 (space-delimited) then appends .nordvpn.com to build the stats URL.
+    # desc format matches nvram vpn_clientX_desc: "NordVPN <hostname_short> <type> <proto>"
     if [ -n "$server" ]; then
         server_short="${server%%.*}"
-        load=$(call get_server_load "NordVPN $server_short" 2>/dev/null) && {
+        load=$(call get_server_load "NordVPN $server_short Standard UDP" 2>/dev/null) && {
             _pass "get_server_load '$server' → ${load}%"
-        } || _fail "get_server_load '$server' — NordVPN /server/stats/ API returns 403 (deprecated by NordVPN; provider needs updating)"
+        } || _fail "get_server_load '$server'"
     else
         _skip "get_server_load — skipped (no server from get_server)"
     fi

--- a/scripts/provider-test.sh
+++ b/scripts/provider-test.sh
@@ -80,6 +80,12 @@ case "$STATUS" in
         echo ""
         NETWORK_TESTS=false
         ;;
+    UNTESTED)
+        _warn "Provider is UNTESTED — implementation not yet verified on a live account"
+        _warn "API tests will run; failures may indicate config errors rather than API changes"
+        echo ""
+        NETWORK_TESTS=true
+        ;;
     UNMAINTAINED)
         _warn "Provider is UNMAINTAINED — API tests may fail if the service has changed"
         echo ""

--- a/scripts/provider-test.sh
+++ b/scripts/provider-test.sh
@@ -178,13 +178,16 @@ else
     start=$(date +%s%3N)
     if call refresh_cache 2>/dev/null; then
         end=$(date +%s%3N); elapsed=$(( end - start ))
-        cache_file="$SCRIPT_DIR/${PROVIDER}_countrydata"
-        if [ -f "$cache_file" ]; then
-            country_count=$(jq 'length' "$cache_file" 2>/dev/null || echo "?")
-            _pass "refresh_cache [${elapsed}ms] — ${country_count} countries cached"
-        else
-            _pass "refresh_cache [${elapsed}ms]"
-        fi
+        # Providers use different cache file names — find whichever exists
+        cache_info=""
+        for _cf in "$SCRIPT_DIR/${PROVIDER}_countrydata" "$SCRIPT_DIR/${PROVIDER}_serverdata"; do
+            if [ -f "$_cf" ]; then
+                _n=$(jq 'if type=="array" then length elif .regions then .regions|length else 0 end' "$_cf" 2>/dev/null || echo "?")
+                cache_info=" — ${_n} regions cached"
+                break
+            fi
+        done
+        _pass "refresh_cache [${elapsed}ms]${cache_info}"
     else
         _fail "refresh_cache — API call failed"
     fi
@@ -256,25 +259,43 @@ else
     fi
 
     # write_certs dry run
+    # CA cert is required by all providers.
+    # Secondary block varies: <tls-auth> (NordVPN) or <crl-verify> (PIA).
     echo ""
     echo -e "${BOLD_FMT}write_certs (dry run)${NC}"
     if [ -n "$ovpn_content" ]; then
         _ca=$(printf '%s' "$ovpn_content" \
             | awk '/<ca>/{flag=1;next}/<\/ca>/{flag=0}flag' | sed '/^#/ d')
-        _static=$(printf '%s' "$ovpn_content" \
-            | awk '/<tls-auth>/{flag=1;next}/<\/tls-auth>/{flag=0}flag' | sed '/^#/ d')
 
-        if [ -n "$_ca" ] && [ -n "$_static" ]; then
-            _pass "CA and tls-auth blocks extractable from OVPN"
-            _info "CA first line:       $(printf '%s\n' "$_ca"     | head -1)"
-            _info "CA last line:        $(printf '%s\n' "$_ca"     | tail -1)"
-            _info "tls-auth first line: $(printf '%s\n' "$_static" | head -1)"
-            _info "Would write: /jffs/openvpn/vpn_crt_client1_ca"
-            _info "             /jffs/openvpn/vpn_crt_client1_static"
-        elif [ -z "$_ca" ]; then
-            _fail "write_certs dry run — <ca> block missing from OVPN"
+        _secondary=""
+        _secondary_label=""
+        _secondary_file=""
+        _tls=$(printf '%s' "$ovpn_content" \
+            | awk '/<tls-auth>/{flag=1;next}/<\/tls-auth>/{flag=0}flag' | sed '/^#/ d')
+        if [ -n "$_tls" ]; then
+            _secondary="$_tls"; _secondary_label="tls-auth"; _secondary_file="static"
         else
-            _fail "write_certs dry run — <tls-auth> block missing from OVPN"
+            _crl=$(printf '%s' "$ovpn_content" \
+                | awk '/<crl-verify>/{flag=1;next}/<\/crl-verify>/{flag=0}flag' | sed '/^#/ d')
+            if [ -n "$_crl" ]; then
+                _secondary="$_crl"; _secondary_label="crl-verify"; _secondary_file="crl"
+            fi
+        fi
+
+        if [ -z "$_ca" ]; then
+            _fail "write_certs dry run — <ca> block missing from OVPN"
+        elif [ -z "$_secondary" ]; then
+            _pass "CA block extractable from OVPN (no tls-auth or crl-verify block)"
+            _info "CA first line: $(printf '%s\n' "$_ca" | head -1)"
+            _info "CA last line:  $(printf '%s\n' "$_ca" | tail -1)"
+            _info "Would write: /jffs/openvpn/vpn_crt_client1_ca"
+        else
+            _pass "CA and ${_secondary_label} blocks extractable from OVPN"
+            _info "CA first line:              $(printf '%s\n' "$_ca"        | head -1)"
+            _info "CA last line:               $(printf '%s\n' "$_ca"        | tail -1)"
+            _info "${_secondary_label} first line: $(printf '%s\n' "$_secondary" | head -1)"
+            _info "Would write: /jffs/openvpn/vpn_crt_client1_ca"
+            _info "             /jffs/openvpn/vpn_crt_client1_${_secondary_file}"
         fi
     else
         _skip "write_certs dry run — skipped (no OVPN content from get_ovpn)"

--- a/scripts/provider-test.sh
+++ b/scripts/provider-test.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# provider-test.sh
+#
+# Exercises a vpnmgr provider module locally against its live API.
+# Requires: curl, jq
+#
+# Usage:
+#   bash scripts/provider-test.sh <provider>
+#   bash scripts/provider-test.sh nordvpn
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# N_PASS/N_FAIL/N_SKIP are test counters.
+# PASS/WARN/ERR/CRIT/BOLD/CLEARFORMAT are colour codes expected by providers.
+# ---------------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BOLD_FMT='\033[1m'
+NC='\033[0m'
+
+N_PASS=0; N_FAIL=0; N_SKIP=0
+
+_pass()  { echo -e "  ${GREEN}✓${NC}  $1"; N_PASS=$((N_PASS + 1)); }
+_fail()  { echo -e "  ${RED}✗${NC}  $1"; N_FAIL=$((N_FAIL + 1)); }
+_skip()  { echo -e "  ${YELLOW}!${NC}  $1"; N_SKIP=$((N_SKIP + 1)); }
+_warn()  { echo -e "  ${YELLOW}WARNING:${NC} $1"; }
+_info()  { echo -e "     $1"; }
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+if [ $# -eq 0 ]; then
+    echo "Usage: bash scripts/provider-test.sh <provider>"
+    echo "       e.g.  bash scripts/provider-test.sh nordvpn"
+    exit 1
+fi
+
+PROVIDER="$1"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PROVIDER_SCRIPT="$REPO_ROOT/providers/provider_${PROVIDER}.sh"
+
+if [ ! -f "$PROVIDER_SCRIPT" ]; then
+    echo -e "${RED}Error:${NC} provider file not found: $PROVIDER_SCRIPT"
+    echo "Available providers:"
+    ls "$REPO_ROOT/providers/provider_"*.sh 2>/dev/null \
+        | sed 's|.*/provider_||; s|\.sh||' | grep -v template | sed 's/^/  /'
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Prerequisites
+# ---------------------------------------------------------------------------
+for cmd in curl jq; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo -e "${RED}Error:${NC} '$cmd' not found — install it before running this script"
+        exit 1
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Provider status
+# ---------------------------------------------------------------------------
+STATUS=$(grep '^# Status:' "$PROVIDER_SCRIPT" | head -1 | sed 's/^# Status: //' | awk '{print $1}')
+
+echo ""
+echo -e "${BOLD_FMT}[provider-test]${NC} ${PROVIDER} provider — local API test"
+echo ""
+
+case "$STATUS" in
+    TEMPLATE)
+        echo -e "${RED}Error:${NC} '$PROVIDER' is the template — not a real provider"
+        exit 1
+        ;;
+    DEPRECATED)
+        _warn "Provider is DEPRECATED — the service is offline"
+        _warn "Network tests will be skipped; only static function tests will run"
+        echo ""
+        NETWORK_TESTS=false
+        ;;
+    UNMAINTAINED)
+        _warn "Provider is UNMAINTAINED — API tests may fail if the service has changed"
+        echo ""
+        NETWORK_TESTS=true
+        ;;
+    *)
+        NETWORK_TESTS=true
+        ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Environment stubs
+# These satisfy router-specific dependencies that don't exist locally.
+# PASS/WARN/ERR/CRIT/BOLD/CLEARFORMAT match the names vpnmgr.sh exports
+# so providers that call Print_Output get the right colour codes.
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="/tmp/vpnmgr_test_$$"
+OVPN_ARCHIVE_DIR="$SCRIPT_DIR/ovpn"
+SCRIPT_REPO="https://raw.githubusercontent.com/h0me5k1n/asusmerlin-nvpnmgr/main"
+
+PASS="\\e[32m"
+WARN="\\e[33m"
+ERR="\\e[31m"
+CRIT="\\e[31m"
+BOLD="\\e[1m"
+CLEARFORMAT="\\e[0m"
+
+Print_Output() { printf '%b%s%b\n' "${3:-}" "$2" "$CLEARFORMAT" >&2; }
+Download_File() { curl -fsL --retry 3 "$1" -o "$2"; }
+Create_Symlinks() { :; }
+
+mkdir -p "$SCRIPT_DIR" "$OVPN_ARCHIVE_DIR"
+trap 'rm -rf "$SCRIPT_DIR"' EXIT
+
+# ---------------------------------------------------------------------------
+# Source the provider, patching /usr/sbin/curl → curl for local dev machines
+# (on the router /usr/sbin/curl exists; locally curl is in PATH)
+# ---------------------------------------------------------------------------
+PATCHED_SCRIPT="$SCRIPT_DIR/provider_${PROVIDER}.sh"
+sed 's|/usr/sbin/curl|curl --globoff|g' "$PROVIDER_SCRIPT" > "$PATCHED_SCRIPT"
+# shellcheck source=/dev/null
+. "$PATCHED_SCRIPT"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+call() {
+    local fn="provider_${PROVIDER}_${1}"
+    shift
+    "$fn" "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Static tests (always run)
+# ---------------------------------------------------------------------------
+echo -e "${BOLD_FMT}Static functions${NC}"
+
+ver=$(call version 2>/dev/null) && _pass "version → $ver" || _fail "version"
+comp=$(call get_comp 2>/dev/null) && _pass "get_comp → $comp" || _fail "get_comp"
+hmac=$(call get_hmac 2>/dev/null) && _pass "get_hmac → $hmac" || _fail "get_hmac"
+
+types_out=$(call get_types 2>/dev/null) && {
+    types_fmt=$(printf '%s' "$types_out" | tr '\n' ',' | sed 's/,$//')
+    _pass "get_types → $types_fmt"
+} || _fail "get_types"
+
+# country_required and city_required return 0 = required, 1 = optional — both are valid
+if call country_required 2>/dev/null; then
+    _pass "country_required → required"
+else
+    _pass "country_required → optional"
+fi
+
+if call city_required 2>/dev/null; then
+    _pass "city_required → required"
+else
+    _pass "city_required → optional"
+fi
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# Network tests
+# ---------------------------------------------------------------------------
+if [ "$NETWORK_TESTS" = "false" ]; then
+    for fn in refresh_cache get_country_names get_country_id get_city_count \
+              get_city_names get_server get_server_load get_ovpn "write_certs dry run"; do
+        _skip "$fn — skipped (deprecated — service offline)"
+    done
+else
+    echo -e "${BOLD_FMT}Network functions${NC}"
+
+    # refresh_cache
+    server=""
+    ovpn_content=""
+    start=$(date +%s%3N)
+    if call refresh_cache 2>/dev/null; then
+        end=$(date +%s%3N); elapsed=$(( end - start ))
+        cache_file="$SCRIPT_DIR/${PROVIDER}_countrydata"
+        if [ -f "$cache_file" ]; then
+            country_count=$(jq 'length' "$cache_file" 2>/dev/null || echo "?")
+            _pass "refresh_cache [${elapsed}ms] — ${country_count} countries cached"
+        else
+            _pass "refresh_cache [${elapsed}ms]"
+        fi
+    else
+        _fail "refresh_cache — API call failed"
+    fi
+
+    # get_country_names
+    names=$(call get_country_names 2>/dev/null) && {
+        total=$(printf '%s\n' "$names" | wc -l | tr -d ' ')
+        preview=$(printf '%s\n' "$names" | head -5 | tr '\n' ',' | sed 's/,$//')
+        _pass "get_country_names — $total countries (${preview}...)"
+    } || _fail "get_country_names"
+
+    # get_country_id for United Kingdom
+    country_name="United Kingdom"
+    country_id=""
+    country_id=$(call get_country_id "$country_name" 2>/dev/null) && {
+        _pass "get_country_id '$country_name' → $country_id"
+    } || {
+        _fail "get_country_id '$country_name' — returned empty"
+        country_id="0"
+    }
+
+    # get_city_count
+    city_count=$(call get_city_count "$country_name" 2>/dev/null) && {
+        _pass "get_city_count '$country_name' → $city_count cities"
+    } || _fail "get_city_count '$country_name'"
+
+    # get_city_names
+    city_names=$(call get_city_names "$country_name" 2>/dev/null) && {
+        cities_fmt=$(printf '%s\n' "$city_names" | tr '\n' ',' | sed 's/,$//')
+        _pass "get_city_names '$country_name' → $cities_fmt"
+    } || _fail "get_city_names '$country_name'"
+
+    # get_server — country only, no city, UDP, Standard
+    start=$(date +%s%3N)
+    server=$(call get_server "$country_id" "$country_name" "0" "" "UDP" "Standard" 2>/dev/null) && {
+        end=$(date +%s%3N); elapsed=$(( end - start ))
+        _pass "get_server [${elapsed}ms] → $server"
+    } || {
+        _fail "get_server — returned empty"
+        server=""
+    }
+
+    # get_server_load
+    # The function expects the nvram vpn_clientX_desc format: "<tag> <hostname_short>"
+    # It cuts field 2 (space-delimited) then appends .nordvpn.com to build the stats URL.
+    if [ -n "$server" ]; then
+        server_short="${server%%.*}"
+        load=$(call get_server_load "NordVPN $server_short" 2>/dev/null) && {
+            _pass "get_server_load '$server' → ${load}%"
+        } || _fail "get_server_load '$server' — NordVPN /server/stats/ API returns 403 (deprecated by NordVPN; provider needs updating)"
+    else
+        _skip "get_server_load — skipped (no server from get_server)"
+    fi
+
+    # get_ovpn
+    if [ -n "$server" ]; then
+        start=$(date +%s%3N)
+        ovpn_content=$(call get_ovpn "$server" "UDP" "Standard" 2>/dev/null) && {
+            end=$(date +%s%3N); elapsed=$(( end - start ))
+            byte_count=${#ovpn_content}
+            _pass "get_ovpn [${elapsed}ms] — ${byte_count} bytes"
+            _info "$(printf '%s\n' "$ovpn_content" | head -8 | sed 's/^/     /')"
+        } || {
+            _fail "get_ovpn — returned empty (CDN unreachable or server not found)"
+            ovpn_content=""
+        }
+    else
+        _skip "get_ovpn — skipped (no server from get_server)"
+        ovpn_content=""
+    fi
+
+    # write_certs dry run
+    echo ""
+    echo -e "${BOLD_FMT}write_certs (dry run)${NC}"
+    if [ -n "$ovpn_content" ]; then
+        _ca=$(printf '%s' "$ovpn_content" \
+            | awk '/<ca>/{flag=1;next}/<\/ca>/{flag=0}flag' | sed '/^#/ d')
+        _static=$(printf '%s' "$ovpn_content" \
+            | awk '/<tls-auth>/{flag=1;next}/<\/tls-auth>/{flag=0}flag' | sed '/^#/ d')
+
+        if [ -n "$_ca" ] && [ -n "$_static" ]; then
+            _pass "CA and tls-auth blocks extractable from OVPN"
+            _info "CA first line:       $(printf '%s\n' "$_ca"     | head -1)"
+            _info "CA last line:        $(printf '%s\n' "$_ca"     | tail -1)"
+            _info "tls-auth first line: $(printf '%s\n' "$_static" | head -1)"
+            _info "Would write: /jffs/openvpn/vpn_crt_client1_ca"
+            _info "             /jffs/openvpn/vpn_crt_client1_static"
+        elif [ -z "$_ca" ]; then
+            _fail "write_certs dry run — <ca> block missing from OVPN"
+        else
+            _fail "write_certs dry run — <tls-auth> block missing from OVPN"
+        fi
+    else
+        _skip "write_certs dry run — skipped (no OVPN content from get_ovpn)"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+TOTAL=$((N_PASS + N_FAIL + N_SKIP))
+echo ""
+echo -e "${BOLD_FMT}─────────────────────────────────────────${NC}"
+if [ $N_FAIL -eq 0 ]; then
+    echo -e "${GREEN}${BOLD_FMT}${N_PASS} passed${NC}, ${N_SKIP} skipped (${TOTAL} total)"
+else
+    echo -e "${RED}${BOLD_FMT}${N_FAIL} failed${NC}, ${N_PASS} passed, ${N_SKIP} skipped (${TOTAL} total)"
+fi
+echo -e "${BOLD_FMT}─────────────────────────────────────────${NC}"
+echo ""
+
+[ $N_FAIL -eq 0 ]


### PR DESCRIPTION
## Summary

- Adds `providers/provider_surfshark.sh` — a new Surfshark VPN provider
- 100 countries, 142 server locations via the public Surfshark clusters API
- OVPN configs are built dynamically (same pattern as PIA): CA cert and TLS-auth key are identical across all servers and embedded as constants; only the `remote` hostname/port differs
- Server selection picks the lowest-load server for the given country and optional city
- Load is cached at `get_server` time and read back by `get_server_load`
- UDP on port 1194, TCP on port 1443
- Status: `UNTESTED` — implementation verified against the live API locally; needs end-to-end verification on a real router with a live Surfshark account before status can be set to `ACTIVE`

## Test plan

- [x] `sh -n providers/provider_surfshark.sh` — syntax clean
- [x] `bash scripts/smoke-test.sh` — 103/103 passed (up from 83)
- [x] `bash scripts/provider-test.sh surfshark` — 15/15 passed against live API
  - refresh_cache: 142 regions downloaded in ~163ms
  - get_country_names: 100 countries
  - get_country_id / get_city_count / get_city_names: correct for United Kingdom (4 cities)
  - get_server: returns lowest-load UK server (e.g. `uk-gla.prod.surfshark.com`)
  - get_server_load: reads cached load percentage
  - get_ovpn: 2817 bytes, correct hostname and protocol in output
  - write_certs dry run: CA and tls-auth blocks extractable
- [ ] End-to-end test on real router with live Surfshark account (required before marking ACTIVE)