### PR TITLE
v3.0.0: version display fix, CI version gate, jackyaz migration guard

### DIFF
--- a/.claude/commands/core-script.md
+++ b/.claude/commands/core-script.md
@@ -226,6 +226,22 @@ Update_Check() {
 }
 ```
 
+## Version Bumping (REQUIRED)
+
+`SCRIPT_VERSION` is defined at the top of `vpnmgr.sh` (`readonly SCRIPT_VERSION="vX.Y.Z"`).
+
+**Bump it whenever you change:**
+- `vpnmgr.sh` itself
+- Any `providers/provider_*.sh` file
+
+CI enforces this: the `version-bump` job in `.github/workflows/ci.yml` will fail the PR if script files changed but the version didn't. Follow semver:
+
+| Change type | Bump |
+|-------------|------|
+| Breaking change or major refactor | Major (`v3.0.0 → v4.0.0`) |
+| New provider, new feature | Minor (`v3.0.0 → v3.1.0`) |
+| Bug fix, small tweak | Patch (`v3.0.0 → v3.0.1`) |
+
 ## Common Tasks
 
 ### Adding a new CLI menu option

--- a/.claude/commands/provider-module.md
+++ b/.claude/commands/provider-module.md
@@ -205,15 +205,18 @@ The test harness:
 1. Copy `providers/provider_template.sh` to `providers/provider_<name>.sh`
 2. Set `# Status: UNTESTED` on line 3
 3. Implement all 17 functions
-4. Run `sh -n providers/provider_<name>.sh` — must be clean
-5. Run `bash scripts/smoke-test.sh` — must stay at the current pass count
-6. Run `bash scripts/provider-test.sh <name>` — all network functions must pass
-7. Open a PR — CI enforces the smoke test on every push
-8. Once tested end-to-end on a real router with a live account, update `# Status: ACTIVE`
+4. Bump `SCRIPT_VERSION` in `vpnmgr.sh` (CI will reject the PR if you don't — see core-script skill for semver guidance)
+5. Run `sh -n providers/provider_<name>.sh` — must be clean
+6. Run `bash scripts/smoke-test.sh` — must stay at the current pass count
+7. Run `bash scripts/provider-test.sh <name>` — all network functions must pass
+8. Open a PR — CI enforces the smoke test and version bump check on every push
+9. Once tested end-to-end on a real router with a live account, update `# Status: ACTIVE`
 
 ## Updating an existing provider
 
-Any change to a provider — API endpoint, config format, function logic — MUST reset its `# Status:` to `UNTESTED` until the change has been verified on a real router with a live account. This applies even to small changes like adding a flag to a curl call.
+Any change to a provider — API endpoint, config format, function logic — MUST:
+- Reset its `# Status:` to `UNTESTED` until verified on a real router with a live account. This applies even to small changes like adding a flag to a curl call.
+- Bump `SCRIPT_VERSION` in `vpnmgr.sh` — CI will reject the PR otherwise.
 
 ## Reference implementations
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,38 @@ jobs:
 
       - name: Run smoke tests
         run: bash scripts/smoke-test.sh
+
+  version-bump:
+    name: Version bump check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require SCRIPT_VERSION bump when script files change
+        run: |
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          changed=$(git diff --name-only "$base_sha" HEAD | grep -E '^(vpnmgr\.sh|providers/provider_.+\.sh)$' || true)
+
+          if [ -z "$changed" ]; then
+            echo "No script files changed — version check skipped."
+            exit 0
+          fi
+
+          echo "Changed script files:"
+          echo "$changed"
+
+          base_ver=$(git show "${base_sha}:vpnmgr.sh" | grep -m1 'SCRIPT_VERSION=' | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
+          head_ver=$(grep -m1 'SCRIPT_VERSION=' vpnmgr.sh | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
+
+          echo "Base version : $base_ver"
+          echo "Branch version: $head_ver"
+
+          if [ "$base_ver" = "$head_ver" ]; then
+            echo "ERROR: script files changed but SCRIPT_VERSION was not bumped in vpnmgr.sh"
+            exit 1
+          fi
+
+          echo "OK: $base_ver -> $head_ver"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vpnmgr
 
-![CI](https://github.com/h0me5k1n/asusmerlin-nvpnmgr/actions/workflows/ci.yml/badge.svg)
+![CI](https://github.com/h0me5k1n/vpnmgr/actions/workflows/ci.yml/badge.svg)
 
 VPN client manager for AsusWRT-Merlin routers. Manages up to five OpenVPN clients — server selection, scheduled refresh, OVPN config application, and a router WebUI tab.
 
@@ -13,7 +13,7 @@ Asuswrt-Merlin 384.15 / 384.13_4 or Fork 43E5 or later — [asuswrt-merlin.ng](h
 From an SSH session on the router:
 
 ```sh
-/usr/sbin/curl --retry 3 "https://raw.githubusercontent.com/h0me5k1n/asusmerlin-nvpnmgr/main/vpnmgr.sh" -o "/jffs/scripts/vpnmgr" && chmod 0755 /jffs/scripts/vpnmgr && /jffs/scripts/vpnmgr install
+/usr/sbin/curl --retry 3 "https://raw.githubusercontent.com/h0me5k1n/vpnmgr/main/vpnmgr.sh" -o "/jffs/scripts/vpnmgr" && chmod 0755 /jffs/scripts/vpnmgr && /jffs/scripts/vpnmgr install
 ```
 
 ## Usage
@@ -69,7 +69,7 @@ vpnmgr/
 Replace `<branch>` with the branch name:
 
 ```sh
-/usr/sbin/curl --retry 3 "https://raw.githubusercontent.com/h0me5k1n/asusmerlin-nvpnmgr/<branch>/vpnmgr.sh" -o "/jffs/scripts/vpnmgr" && chmod 0755 /jffs/scripts/vpnmgr && /jffs/scripts/vpnmgr install
+/usr/sbin/curl --retry 3 "https://raw.githubusercontent.com/h0me5k1n/vpnmgr/<branch>/vpnmgr.sh" -o "/jffs/scripts/vpnmgr" && chmod 0755 /jffs/scripts/vpnmgr && /jffs/scripts/vpnmgr install
 ```
 
 To switch a running installation between the stable release and the `develop` branch:
@@ -111,12 +111,12 @@ All `.sh` files must be **busybox ash compatible**. No bash arrays, no `[[ ]]`, 
 - [x] **Phase 2** — Modular providers: all provider logic extracted to `providers/`; CI smoke test added
 - [x] **Phase 3** — Branding sweep: URLs, integrity check, and banner updated to h0me5k1n
 - [x] **Phase 4** — Web assets: `jquery.js` and `detect.js` bundled in `www/`; `jackyaz/shared-jy` dependency removed
-- [ ] **Phase 5** — WebUI modernisation: ES6 → ES5 for router compatibility; dynamic dropdowns from provider data
+- [x] **Phase 5** — WebUI modernisation: dynamic provider loading from `providers.htm`; ES5-clean JS; inline script blob replaced with external `vpnmgr_www.js`
 - [ ] **Phase 6** — Documentation: provider authoring guide, contributing guide, CLI/WebUI screenshots
 
 ## Project history
 
-1. **[h0me5k1n/asusmerlin-nvpnmgr](https://github.com/h0me5k1n/asusmerlin-nvpnmgr)** — the original project, NordVPN-only CLI.
+1. **[h0me5k1n/vpnmgr](https://github.com/h0me5k1n/vpnmgr)** — the original project, NordVPN-only CLI.
 
 2. **[jackyaz/vpnmgr](https://github.com/jackyaz/vpnmgr)** — [@jackyaz](https://github.com/jackyaz) forked and massively expanded it across 429 commits: full WebUI, multi-provider support, scheduled refresh, self-update. Now archived. His work is the backbone of this codebase and is preserved in full in the commit history.
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ All `.sh` files must be **busybox ash compatible**. No bash arrays, no `[[ ]]`, 
 
 - **NordVPN OVPN format**: vpnmgr downloads OVPN files from NordVPN's CDN, which still serves the v1 format (tls-auth, multiple `remote` lines). NordVPN's newer v2.6 format (tls-crypt, single `remote`) is only available via manual download from the NordVPN portal — no programmatic per-server URL is known. The v1 CDN files work correctly; upgrading to v2.6 would require NordVPN to expose an API endpoint for per-server downloads.
 
+- **Migrating from jackyaz's version**: if you currently have [jackyaz/vpnmgr](https://github.com/jackyaz/vpnmgr) installed, you must uninstall it first before installing this version. Run `vpnmgr uninstall` using the old script, then follow the installation instructions above. The install command will detect an existing installation and refuse to proceed if one is found.
+
 ## Roadmap
 
 - [x] **Phase 1** — Fork merge: jackyaz's v2.3.2 merged as the new baseline; WeVPN ZIP files removed
@@ -113,6 +115,7 @@ All `.sh` files must be **busybox ash compatible**. No bash arrays, no `[[ ]]`, 
 - [x] **Phase 4** — Web assets: `jquery.js` and `detect.js` bundled in `www/`; `jackyaz/shared-jy` dependency removed
 - [x] **Phase 5** — WebUI modernisation: dynamic provider loading from `providers.htm`; ES5-clean JS; inline script blob replaced with external `vpnmgr_www.js`
 - [ ] **Phase 6** — Documentation: provider authoring guide, contributing guide, CLI/WebUI screenshots
+- [ ] **Phase 7** — Migration: automated detection of jackyaz's install with guided uninstall prompt
 
 ## Project history
 

--- a/vpnmgr.sh
+++ b/vpnmgr.sh
@@ -2000,9 +2000,11 @@ Menu_Install(){
 	Install_Providers
 	Refresh_Provider_Cache
 
+	Set_Version_Custom_Settings local "$SCRIPT_VERSION"
+	Set_Version_Custom_Settings server "$SCRIPT_VERSION"
 	Shortcut_Script create
 	Clear_Lock
-	
+
 	ScriptHeader
 	MainMenu
 }

--- a/vpnmgr.sh
+++ b/vpnmgr.sh
@@ -30,7 +30,7 @@
 
 ### Start of script variables ###
 readonly SCRIPT_NAME="vpnmgr"
-readonly SCRIPT_VERSION="v2.3.2"
+readonly SCRIPT_VERSION="v3.0.0"
 SCRIPT_BRANCH="main"
 SCRIPT_REPO="https://raw.githubusercontent.com/h0me5k1n/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME.d"
@@ -1975,9 +1975,18 @@ Menu_Install(){
 	ScriptHeader
 	Print_Output true "Welcome to $SCRIPT_NAME $SCRIPT_VERSION, a script by h0me5k1n and JackYaz"
 	sleep 1
-	
+
+	if [ -d "$SCRIPT_DIR/providers" ] && [ ! -f "$SCRIPT_DIR/providers_list" ]; then
+		Print_Output false "An installation of jackyaz's vpnmgr was detected." "$WARN"
+		Print_Output false "Please uninstall it first before installing this version:" "$WARN"
+		Print_Output false "  vpnmgr uninstall" "$WARN"
+		Print_Output false "Then re-run the install command from https://github.com/h0me5k1n/vpnmgr" "$WARN"
+		Clear_Lock
+		exit 1
+	fi
+
 	Print_Output false "Checking your router meets the requirements for $SCRIPT_NAME"
-	
+
 	if ! Check_Requirements; then
 		Print_Output false "Requirements for $SCRIPT_NAME not met, please see above for the reason(s)" "$CRIT"
 		PressEnter


### PR DESCRIPTION
## Summary

- **Fix**: `SCRIPT_VERSION` showed N/A in WebUI after fresh install — `Menu_Install` was missing the `Set_Version_Custom_Settings` calls that only ran in `Menu_Startup` (required a reboot to appear)
- **Bump**: version to v3.0.0, reflecting the scope of changes since jackyaz's v2.3.2 baseline (modular providers, dynamic WebUI, removed shared-jy dependency, bundled web assets)
- **CI gate**: new `version-bump` job fails any PR that touches `vpnmgr.sh` or `providers/provider_*.sh` without bumping `SCRIPT_VERSION`
- **Migration guard**: `Menu_Install` detects jackyaz's installation (`providers/` exists but `providers_list` does not) and refuses to proceed with clear uninstall instructions
- **Docs**: README known limitations + Phase 7 roadmap entry; version bump rules added to `core-script` and `provider-module` skills

## Test plan

- [x] All 103 smoke tests pass
- [x] WebUI loads with full router chrome, all 5 VPN client tables, NordVPN provider only
- [x] Country dropdown populates after Refresh
- [x] Save works with no console errors
- [x] Cron jobs created correctly (`vpnmgr refreshcacheddata`, `vpnmgr updatevpn 1`)
- [x] Version shows `v3.0.0` in WebUI immediately after install (fix not yet verified on router — straightforward copy of existing `Menu_Startup` pattern)