### PR TITLE
Clean up SetVPNCustomSettings for OpenVPN 2.6

### DIFF
--- a/vpnmgr.sh
+++ b/vpnmgr.sh
@@ -30,7 +30,7 @@
 
 ### Start of script variables ###
 readonly SCRIPT_NAME="vpnmgr"
-readonly SCRIPT_VERSION="v3.0.0"
+readonly SCRIPT_VERSION="v3.0.1"
 SCRIPT_BRANCH="main"
 SCRIPT_REPO="https://raw.githubusercontent.com/h0me5k1n/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME.d"

--- a/vpnmgr.sh
+++ b/vpnmgr.sh
@@ -1650,21 +1650,20 @@ resolv-retry infinite
 remote-cert-tls server
 ping 15
 ping-restart 60
+ping-timer-rem
 persist-key
 persist-tun
 reneg-sec 0
 fast-io
-disable-occ
 mute-replay-warnings
 sndbuf 524288
 rcvbuf 524288
-push "sndbuf 524288"
-push "rcvbuf 524288"
 pull-filter ignore "auth-token"
 pull-filter ignore "ifconfig-ipv6"
 pull-filter ignore "route-ipv6"
 pull-filter ignore "ping"
-pull-filter ignore "ping-restart"'
+pull-filter ignore "ping-restart"
+auth-nocache'
 	
 	if [ "$VPN_PROT_SHORT" = "UDP" ]; then
 		vpncustomoptions="$vpncustomoptions


### PR DESCRIPTION
## Summary

- Remove `disable-occ` — option was removed in OpenVPN 2.5+, dead code in 2.6.x
- Remove `push "sndbuf 524288"` and `push "rcvbuf 524288"` — `push` is a server-only directive; no-op on a client and duplicated by the `sndbuf`/`rcvbuf` lines above
- Add `ping-timer-rem` — present in NordVPN OVPN files and NordVPN's official Merlin setup guide; resets the ping-restart countdown on any received traffic (not just ping replies), preventing premature reconnects when the tunnel has active traffic
- Add `auth-nocache` — suppresses `WARNING: this configuration may cache passwords in memory` which appears on every new OpenVPN process start when userauth is in use

## Test plan

- [x] Deployed branch to router via `scp -O`
- [x] Triggered `updatevpn 1` manually — vpnmgr rewrote custom3 file and restarted client
- [x] Verified `/jffs/openvpn/vpn_client1_custom3` contains new settings
- [x] Confirmed `WARNING: this configuration may cache passwords in memory` absent from syslog on new OpenVPN process (PID 828)
- [x] Connection established successfully — `Initialization Sequence Completed`, ping test passed